### PR TITLE
Develop to staging (#117)

### DIFF
--- a/pocket-gateway/ecs-task-us-east-2.json
+++ b/pocket-gateway/ecs-task-us-east-2.json
@@ -25,7 +25,7 @@
     "environment": [],
 		"command": [],
 		"linuxParameters": null,
-		"cpu": 2048,
+		"cpu": 4096,
 		"resourceRequirements": null,
 		"ulimits": [
 			{

--- a/stacks/local.init.sql
+++ b/stacks/local.init.sql
@@ -1,0 +1,19 @@
+-- Local setup of timescaledb relations
+
+CREATE TABLE relay (
+  timestamp TIMESTAMPTZ NOT NULL,
+  app_pub_key TEXT NOT NULL,
+  blockchain TEXT NOT NULL,
+  service_node TEXT,
+  elapsed_time DOUBLE PRECISION NOT NULL,
+  result NUMERIC,
+  bytes NUMERIC NOT NULL,
+  method TEXT
+);
+
+CREATE INDEX relay_app_pub_key_method_timestamp_idx ON relay(app_pub_key, method, timestamp);
+CREATE INDEX relay_app_pub_key_result_timestamp_idx ON relay(app_pub_key, result, timestamp);
+CREATE INDEX relay_app_pub_key_timestamp_idx ON relay(app_pub_key, timestamp DESC);
+CREATE INDEX relay_service_node_timestamp_idx ON relay(service_node, timestamp DESC);
+CREATE INDEX relay_timestamp_app_pub_key_idx ON relay(timestamp DESC, app_pub_key);
+CREATE INDEX relay_timestamp_idx ON relay(timestamp DESC);

--- a/stacks/local.yml
+++ b/stacks/local.yml
@@ -56,7 +56,9 @@ services:
       - 5432:5432
     networks:
       - pocket
-
+    volumes:
+      - ./local.init.sql:/docker-entrypoint-initdb.d/init.sql
+   
 networks:
   pocket:
     driver: bridge


### PR DESCRIPTION
* updating loopback 4

* pinning mongo version

* removing comment from .env line which was breaking the import

* removing comment that is breaking env example

* making scripts use diff connection strings per instance

* simplifying data import

* making gateway wait for other services

* fixes #83; lb cannot be found due to blockchain subdomain hack

* New altruist implementation (#100)

* new altruist implementation

* adding check for blank relaypath, not just undefined

* Updating example to match realities

* pushing feature branch to staging

* fixing bad subdomain parsing

* removing subdomain hack, localhost can work with subdomains

* db test for staging

* db test for staging

* db test for staging

* db test for staging

* fixing logging of debug and wrapping axios in try catch

* testing on usw2

* fixing memory reservation for fargate

* removing excess logging, vestigal interfaces

* restoring CORS headers

* restoring CORS headers

* restoring CORS headers

* restoring CORS headers

* restoring CORS headers

* restoring push on master to production files

* updating requires to imports, resolving PR comments

* reverting logger import change

* pushing to usw2

* pointing workflows back to correct branches

* Update task for e2

* feat: add local setup of relations in timescaledb

* Adding back missing allowed headers (#112)

* new altruist implementation

* adding check for blank relaypath, not just undefined

* Updating example to match realities

* pushing feature branch to staging

* fixing bad subdomain parsing

* removing subdomain hack, localhost can work with subdomains

* db test for staging

* db test for staging

* db test for staging

* db test for staging

* fixing logging of debug and wrapping axios in try catch

* testing on usw2

* fixing memory reservation for fargate

* removing excess logging, vestigal interfaces

* restoring CORS headers

* restoring CORS headers

* restoring CORS headers

* restoring CORS headers

* restoring CORS headers

* restoring push on master to production files

* updating requires to imports, resolving PR comments

* reverting logger import change

* pushing to usw2

* pointing workflows back to correct branches

* adding back origin,ua headers

* fixes #108; uses altruist system as backup for sync check

* removing leftover cache breaker and changing it to 30 second redis cache for failure sessions

Co-authored-by: Roniel Valdez <roniel_valdez@outlook.com>