### PR TITLE
Pocketjs mock improvements

### DIFF
--- a/tests/unit/chain-checker.unit.ts
+++ b/tests/unit/chain-checker.unit.ts
@@ -9,7 +9,7 @@ import { MetricsRecorder } from '../../src/services/metrics-recorder'
 import { metricsRecorderMock } from '../mocks/metricsRecorder'
 import { DEFAULT_NODES, PocketMock } from '../mocks/pocketjs'
 
-const CHAINCHECK_URL = '{"method":"eth_chainId","id":1,"jsonrpc":"2.0"}'
+const CHAINCHECK_PAYLOAD = '{"method":"eth_chainId","id":1,"jsonrpc":"2.0"}'
 
 describe('Chain checker service (unit)', () => {
   let chainChecker: ChainChecker
@@ -41,8 +41,7 @@ describe('Chain checker service (unit)', () => {
 
   const clean = async () => {
     pocketMock = new PocketMock(undefined, undefined, pocketConfiguration)
-    pocketMock.relayRequest = CHAINCHECK_URL
-    pocketMock.relayResponse = '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
+    pocketMock.relayResponse[CHAINCHECK_PAYLOAD] = '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
 
     await redis.flushall()
     sinon.restore()
@@ -101,8 +100,7 @@ describe('Chain checker service (unit)', () => {
     it('Retrieve the logs of a node', async () => {
       const node = DEFAULT_NODES[0]
 
-      pocketMock.relayRequest = CHAINCHECK_URL
-      pocketMock.relayResponse = '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
+      pocketMock.relayResponse[CHAINCHECK_PAYLOAD] = '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
 
       const pocketClient = pocketMock.getObject()
 
@@ -110,7 +108,7 @@ describe('Chain checker service (unit)', () => {
         node,
         requestID: '1234',
         blockchain: '100',
-        chainCheck: CHAINCHECK_URL,
+        chainCheck: CHAINCHECK_PAYLOAD,
         pocket: pocketClient,
         applicationID: '',
         applicationPublicKey: '',
@@ -127,7 +125,6 @@ describe('Chain checker service (unit)', () => {
     it('Fails gracefully on handled error result', async () => {
       const node = DEFAULT_NODES[0]
 
-      pocketMock.relayRequest = CHAINCHECK_URL
       pocketMock.fail = true
 
       const pocketClient = pocketMock.getObject()
@@ -136,7 +133,7 @@ describe('Chain checker service (unit)', () => {
         node,
         requestID: '1234',
         blockchain: '100',
-        chainCheck: CHAINCHECK_URL,
+        chainCheck: CHAINCHECK_PAYLOAD,
         pocket: pocketClient,
         applicationID: '',
         applicationPublicKey: '',
@@ -153,9 +150,8 @@ describe('Chain checker service (unit)', () => {
     it('Fails gracefully on unhandled error result', async () => {
       const node = DEFAULT_NODES[0]
 
-      pocketMock.relayRequest = CHAINCHECK_URL
       // Invalid JSON string
-      pocketMock.relayResponse = 'id":1,"jsonrp:"2.0","result": "0x64"}'
+      pocketMock.relayResponse[CHAINCHECK_PAYLOAD] = 'id":1,"jsonrp:"2.0","result": "0x64"}'
 
       const pocketClient = pocketMock.getObject()
 
@@ -163,7 +159,7 @@ describe('Chain checker service (unit)', () => {
         node,
         requestID: '1234',
         blockchain: '100',
-        chainCheck: CHAINCHECK_URL,
+        chainCheck: CHAINCHECK_PAYLOAD,
         pocket: pocketClient,
         applicationID: '',
         applicationPublicKey: '',
@@ -187,7 +183,7 @@ describe('Chain checker service (unit)', () => {
       nodes,
       requestID: '1234',
       blockchain: '100',
-      chainCheck: CHAINCHECK_URL,
+      chainCheck: CHAINCHECK_PAYLOAD,
       pocket: pocketClient,
       applicationID: '',
       applicationPublicKey: '',
@@ -217,7 +213,7 @@ describe('Chain checker service (unit)', () => {
       nodes,
       requestID: '1234',
       blockchain: '100',
-      chainCheck: CHAINCHECK_URL,
+      chainCheck: CHAINCHECK_PAYLOAD,
       pocket: pocketClient,
       applicationID: '',
       applicationPublicKey: '',
@@ -237,7 +233,7 @@ describe('Chain checker service (unit)', () => {
       nodes,
       requestID: '1234',
       blockchain: '100',
-      chainCheck: CHAINCHECK_URL,
+      chainCheck: CHAINCHECK_PAYLOAD,
       pocket: pocketClient,
       applicationID: '',
       applicationPublicKey: '',
@@ -254,7 +250,7 @@ describe('Chain checker service (unit)', () => {
     const nodes = DEFAULT_NODES
 
     // Default nodes are set with a chainID of 100
-    pocketMock.relayResponse = '{"id":1,"jsonrpc":"2.0","result":"0xC8"}' // 0xC8 to base 10: 200
+    pocketMock.relayResponse[CHAINCHECK_PAYLOAD] = '{"id":1,"jsonrpc":"2.0","result":"0xC8"}' // 0xC8 to base 10: 200
 
     const pocketClient = pocketMock.getObject()
 
@@ -264,7 +260,7 @@ describe('Chain checker service (unit)', () => {
       nodes,
       requestID: '1234',
       blockchain: chainID.toString(),
-      chainCheck: CHAINCHECK_URL,
+      chainCheck: CHAINCHECK_PAYLOAD,
       pocket: pocketClient,
       applicationID: '',
       applicationPublicKey: '',

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -397,7 +397,8 @@ describe('Pocket relayer service (unit)', () => {
     }
 
     beforeEach(async () => {
-      rawData = '{"method":"eth_blockNumber","params":[],"id":1,"jsonrpc":"2.0"}'
+      // Default data of pocketJS mock
+      rawData = Object.keys(pocketMock.relayResponse)[0]
 
       await createBlockchain()
     })
@@ -413,8 +414,7 @@ describe('Pocket relayer service (unit)', () => {
         overallTimeOut: undefined,
         relayRetries: 0,
       })
-
-      const expected = JSON.parse(pocketMock.relayResponse as string)
+      const expected = JSON.parse(pocketMock.relayResponse[rawData] as string)
 
       expect(relayResponse).to.be.deepEqual(expected)
     })
@@ -422,7 +422,7 @@ describe('Pocket relayer service (unit)', () => {
     it('sends successful relay response as string', async () => {
       const mock = new PocketMock()
 
-      mock.relayResponse = 'string response'
+      mock.relayResponse[rawData] = 'string response'
 
       const pocket = mock.getObject()
 
@@ -457,7 +457,7 @@ describe('Pocket relayer service (unit)', () => {
         relayRetries: 0,
       })
 
-      const expected = mock.relayResponse
+      const expected = mock.relayResponse[rawData]
 
       expect(relayResponse).to.be.deepEqual(expected)
     })
@@ -506,7 +506,7 @@ describe('Pocket relayer service (unit)', () => {
     it('returns relay error on successful relay response that returns error', async () => {
       const mock = new PocketMock()
 
-      mock.relayResponse = '{"error": "a relay error"}'
+      mock.relayResponse[rawData] = '{"error": "a relay error"}'
 
       const pocket = mock.getObject()
 
@@ -584,7 +584,7 @@ describe('Pocket relayer service (unit)', () => {
         relayRetries: 0,
       })
 
-      expect(relayResponse).to.be.deepEqual(JSON.parse(pocketMock.relayResponse as string))
+      expect(relayResponse).to.be.deepEqual(JSON.parse(pocketMock.relayResponse[rawData] as string))
 
       expect(mockCheckerSpy.callCount).to.be.equal(1)
       expect(syncCherckerSpy.callCount).to.be.equal(1)
@@ -876,7 +876,7 @@ describe('Pocket relayer service (unit)', () => {
       }
 
       it('sends a relay post request to an altruist node when no session nodes are available', async () => {
-        const axiosRelayResponse = JSON.parse(pocketMock.relayResponse as string)
+        const axiosRelayResponse = JSON.parse(pocketMock.relayResponse[rawData] as string)
 
         axiosMock.onPost(ALTRUISTS['0021']).reply(200, axiosRelayResponse)
 
@@ -897,7 +897,7 @@ describe('Pocket relayer service (unit)', () => {
       })
 
       it('sends a relay get request to an altruist node when no session nodes are available', async () => {
-        const axiosRelayResponse = JSON.parse(pocketMock.relayResponse as string)
+        const axiosRelayResponse = JSON.parse(pocketMock.relayResponse[rawData] as string)
 
         axiosMock.onGet(ALTRUISTS['0021']).reply(200, axiosRelayResponse)
 


### PR DESCRIPTION
- [X] can add custom responses for custom requests
- [X] can add continuous responses to request, for example calling a sync check three times can return only two valid nodes, varying the responses on each call to the same request 
- [X] improve naming of methods, variables and add jsdoc convention
- [X] Fix bug on class instance where methods didn't really work, remove unused code