### PR TITLE
Fix pocketjs mock method name errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,14 @@ module.exports = {
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-extra-semi': ['off'],
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'variable',
+        format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+        leadingUnderscore: 'allow',
+      },
+    ],
     '@typescript-eslint/ban-types': [
       'error',
       {

--- a/src/application.ts
+++ b/src/application.ts
@@ -12,8 +12,7 @@ import AatPlans from './config/aat-plans.json'
 
 const logger = require('./services/logger')
 
-const pocketJS = require('@pokt-network/pocket-js')
-const { Pocket, Configuration, HttpRpcProvider } = pocketJS
+import { Pocket, Configuration, HttpRpcProvider } from '@pokt-network/pocket-js'
 
 import Redis from 'ioredis'
 import crypto from 'crypto'

--- a/src/errors/relay-error.ts
+++ b/src/errors/relay-error.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 /**
  * @class RelayError
  */

--- a/src/services/relay-profiler.ts
+++ b/src/services/relay-profiler.ts
@@ -6,7 +6,6 @@ import { Pool as PGPool } from 'pg'
 // const logger = require('../services/logger');
 
 export class RelayProfiler extends BaseProfiler {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   public data: { key: string; time_elapsed: number | undefined }[] = []
   pgPool: PGPool
 

--- a/tests/mocks/metricsRecorder.ts
+++ b/tests/mocks/metricsRecorder.ts
@@ -1,4 +1,4 @@
-import { expect, sinon } from '@loopback/testlab'
+import { sinon } from '@loopback/testlab'
 import { Pool } from 'pg'
 import rewiremock from 'rewiremock'
 import { InfluxDB, WriteApi } from '@influxdata/influxdb-client'

--- a/tests/unit/chain-checker.unit.ts
+++ b/tests/unit/chain-checker.unit.ts
@@ -102,7 +102,7 @@ describe('Chain checker service (unit)', () => {
 
       pocketMock.relayResponse[CHAINCHECK_PAYLOAD] = '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
 
-      const pocketClient = pocketMock.getObject()
+      const pocketClient = pocketMock.object()
 
       const nodeLog = await chainChecker.getNodeChainLog({
         node,
@@ -127,7 +127,7 @@ describe('Chain checker service (unit)', () => {
 
       pocketMock.fail = true
 
-      const pocketClient = pocketMock.getObject()
+      const pocketClient = pocketMock.object()
 
       const nodeLog = await chainChecker.getNodeChainLog({
         node,
@@ -153,7 +153,7 @@ describe('Chain checker service (unit)', () => {
       // Invalid JSON string
       pocketMock.relayResponse[CHAINCHECK_PAYLOAD] = 'id":1,"jsonrp:"2.0","result": "0x64"}'
 
-      const pocketClient = pocketMock.getObject()
+      const pocketClient = pocketMock.object()
 
       const nodeLog = await chainChecker.getNodeChainLog({
         node,
@@ -177,7 +177,7 @@ describe('Chain checker service (unit)', () => {
   it('Retrieve the logs of a all the nodes in a pocket session', async () => {
     const nodes = DEFAULT_NODES
 
-    const pocketClient = pocketMock.getObject()
+    const pocketClient = pocketMock.object()
 
     const nodeLogs = await chainChecker.getNodeChainLogs({
       nodes,
@@ -202,7 +202,7 @@ describe('Chain checker service (unit)', () => {
   it('performs the chain check successfully', async () => {
     const nodes = DEFAULT_NODES
 
-    const pocketClient = pocketMock.getObject()
+    const pocketClient = pocketMock.object()
 
     const chainID = 100
 
@@ -252,7 +252,7 @@ describe('Chain checker service (unit)', () => {
     // Default nodes are set with a chainID of 100
     pocketMock.relayResponse[CHAINCHECK_PAYLOAD] = '{"id":1,"jsonrpc":"2.0","result":"0xC8"}' // 0xC8 to base 10: 200
 
-    const pocketClient = pocketMock.getObject()
+    const pocketClient = pocketMock.object()
 
     const chainID = 100
 

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -140,7 +140,7 @@ describe('Pocket relayer service (unit)', () => {
 
     pocketMock = new PocketMock(undefined, undefined, pocketConfiguration)
 
-    const pocket = pocketMock.getObject()
+    const pocket = pocketMock.object()
 
     pocketRelayer = new PocketRelayer({
       host: DEFAULT_HOST,
@@ -233,7 +233,7 @@ describe('Pocket relayer service (unit)', () => {
   })
 
   it('checks secret of application when set', () => {
-    const pocket = pocketMock.getObject()
+    const pocket = pocketMock.object()
 
     const encryptor = new Encryptor({ key: DB_ENCRYPTION_KEY })
 
@@ -424,7 +424,7 @@ describe('Pocket relayer service (unit)', () => {
 
       mock.relayResponse[rawData] = 'string response'
 
-      const pocket = mock.getObject()
+      const pocket = mock.object()
 
       const poktRelayer = new PocketRelayer({
         host: 'eth-mainnet-string',
@@ -467,7 +467,7 @@ describe('Pocket relayer service (unit)', () => {
 
       mock.fail = true
 
-      const pocket = mock.getObject()
+      const pocket = mock.object()
 
       const poktRelayer = new PocketRelayer({
         host: 'mainnet',
@@ -508,7 +508,7 @@ describe('Pocket relayer service (unit)', () => {
 
       mock.relayResponse[rawData] = '{"error": "a relay error"}'
 
-      const pocket = mock.getObject()
+      const pocket = mock.object()
 
       const poktRelayer = new PocketRelayer({
         host: 'mainnet',
@@ -551,7 +551,7 @@ describe('Pocket relayer service (unit)', () => {
 
       const syncCherckerSpy = sinon.spy(syncChecker, 'consensusFilter')
 
-      const pocket = pocketMock.getObject()
+      const pocket = pocketMock.object()
 
       const poktRelayer = new PocketRelayer({
         host: 'eth-mainnet',
@@ -597,7 +597,7 @@ describe('Pocket relayer service (unit)', () => {
 
       const syncCherckerSpy = sinon.spy(syncChecker, 'consensusFilter')
 
-      const pocket = pocketMock.getObject()
+      const pocket = pocketMock.object()
 
       const poktRelayer = new PocketRelayer({
         host: 'eth-mainnet',
@@ -643,7 +643,7 @@ describe('Pocket relayer service (unit)', () => {
 
       const syncCherckerSpy = sinon.spy(syncChecker, 'consensusFilter')
 
-      const pocket = pocketMock.getObject()
+      const pocket = pocketMock.object()
 
       const poktRelayer = new PocketRelayer({
         host: 'eth-mainnet',
@@ -695,7 +695,7 @@ describe('Pocket relayer service (unit)', () => {
 
         application.gatewaySettings = gatewaySettings
 
-        const pocket = pocketMock.getObject()
+        const pocket = pocketMock.object()
 
         const poktRelayer = new PocketRelayer({
           host: 'mainnet',
@@ -746,7 +746,7 @@ describe('Pocket relayer service (unit)', () => {
 
         application.gatewaySettings = gatewaySettings
 
-        const pocket = pocketMock.getObject()
+        const pocket = pocketMock.object()
 
         const invalidOrigin = 'invalid-origin'
 
@@ -799,7 +799,7 @@ describe('Pocket relayer service (unit)', () => {
 
         application.gatewaySettings = gatewaySettings
 
-        const pocket = pocketMock.getObject()
+        const pocket = pocketMock.object()
 
         const invalidUserAgent = 'invalid-user-agent'
 
@@ -850,7 +850,7 @@ describe('Pocket relayer service (unit)', () => {
       const getAltruistRelayer = (): PocketRelayer => {
         const { chainChecker: mockChainChecker, syncChecker: mockSyncChecker } = mockChainAndSyncChecker(0, 5)
 
-        const pocket = pocketMock.getObject()
+        const pocket = pocketMock.object()
 
         const poktRelayer = new PocketRelayer({
           host: 'eth-mainnet',

--- a/tests/unit/sync-checker.unit.ts
+++ b/tests/unit/sync-checker.unit.ts
@@ -126,7 +126,7 @@ describe('Sync checker service (unit)', () => {
     it('retrieves the sync logs of a node', async () => {
       const node = DEFAULT_NODES[0]
 
-      const pocket = pocketMock.getObject()
+      const pocket = pocketMock.object()
 
       const nodeSyncLog = await syncChecker.getNodeSyncLog(
         node,
@@ -153,7 +153,7 @@ describe('Sync checker service (unit)', () => {
 
       pocketMock.fail = true
 
-      const pocket = pocketMock.getObject()
+      const pocket = pocketMock.object()
 
       const nodeSyncLog = await syncChecker.getNodeSyncLog(
         node,
@@ -181,7 +181,7 @@ describe('Sync checker service (unit)', () => {
       // Invalid JSON string
       pocketMock.relayResponse[blockchain.syncCheck] = 'method":eth_blockNumber","id":,"jsonrpc""2.0"}'
 
-      const pocket = pocketMock.getObject()
+      const pocket = pocketMock.object()
 
       const nodeSyncLog = await syncChecker.getNodeSyncLog(
         node,
@@ -229,7 +229,7 @@ describe('Sync checker service (unit)', () => {
   it('Retrieve the sync logs of a all the nodes in a pocket session', async () => {
     const nodes = DEFAULT_NODES
 
-    const pocketClient = pocketMock.getObject()
+    const pocketClient = pocketMock.object()
 
     const nodeLogs = await syncChecker.getNodeSyncLogs(
       nodes,
@@ -256,7 +256,7 @@ describe('Sync checker service (unit)', () => {
     it('performs the sync check successfully', async () => {
       const nodes = DEFAULT_NODES
 
-      const pocketClient = pocketMock.getObject()
+      const pocketClient = pocketMock.object()
 
       const redisGetSpy = sinon.spy(redis, 'get')
       const redisSetSpy = sinon.spy(redis, 'set')
@@ -306,7 +306,7 @@ describe('Sync checker service (unit)', () => {
 
       pocketMock.fail = true
 
-      const pocketClient = pocketMock.getObject()
+      const pocketClient = pocketMock.object()
 
       const syncedNodes = await syncChecker.consensusFilter({
         nodes,
@@ -339,7 +339,7 @@ describe('Sync checker service (unit)', () => {
         penalizedNode,
       ]
 
-      const pocketClient = pocketMock.getObject()
+      const pocketClient = pocketMock.object()
 
       const syncedNodes = await syncChecker.consensusFilter({
         nodes,
@@ -377,7 +377,7 @@ describe('Sync checker service (unit)', () => {
         secondHighestNode,
       ]
 
-      const pocketClient = pocketMock.getObject()
+      const pocketClient = pocketMock.object()
 
       const syncedNodes = await syncChecker.consensusFilter({
         nodes,


### PR DESCRIPTION
Currently the change of method names of the pocketjs mock lead to build errors on the unit tests that relied on them, this is fixed here, also add more flexible rules regarding name convention so we don't always have to rely on eslint disable which has become the rule rather than the exception