### PR TITLE
Fix default log limit of 0 when not set in db or env vars

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -76,7 +76,7 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
     const relayRetries: string = POCKET_RELAY_RETRIES || ''
     const databaseEncryptionKey: string = DATABASE_ENCRYPTION_KEY || ''
     const defaultSyncAllowance: number = parseInt(DEFAULT_SYNC_ALLOWANCE) || -1
-    const defaultLogLimitBlocks: number = parseInt(DEFAULT_LOG_LIMIT_BLOCKS) || -1
+    const defaultLogLimitBlocks: number = parseInt(DEFAULT_LOG_LIMIT_BLOCKS) || 10000
     const aatPlan = AAT_PLAN || AatPlans.PREMIUM
     const redirects = REDIRECTS || '' // Can be empty
 

--- a/src/config/pocket-config.ts
+++ b/src/config/pocket-config.ts
@@ -15,7 +15,7 @@ export type PocketConfiguration = {
 }
 
 export const DEFAULT_POCKET_CONFIG = {
-  maxDispatchers: 50,
+  maxDispatchers: 24,
   maxSessions: 100000,
   consensusNodeCount: 5,
   requestTimeout: 120000, // 3 minutes

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -41,6 +41,7 @@ export class V1Controller {
     @inject('defaultSyncAllowance') private defaultSyncAllowance: number,
     @inject('aatPlan') private aatPlan: string,
     @inject('redirects') private redirects: string,
+    @inject('defaultLogLimitBlocks') private defaultLogLimitBlocks: number,
     @repository(ApplicationsRepository)
     public applicationsRepository: ApplicationsRepository,
     @repository(BlockchainsRepository)
@@ -78,6 +79,7 @@ export class V1Controller {
       checkDebug: this.checkDebug(),
       altruists: this.altruists,
       aatPlan: this.aatPlan,
+      defaultLogLimitBlocks: this.defaultLogLimitBlocks,
     })
   }
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -36,6 +36,7 @@ export class PocketRelayer {
   checkDebug: boolean
   altruists: JSONObject
   aatPlan: string
+  defaultLogLimitBlocks: number
 
   constructor({
     host,
@@ -55,6 +56,7 @@ export class PocketRelayer {
     checkDebug,
     altruists,
     aatPlan,
+    defaultLogLimitBlocks,
   }: {
     host: string
     origin: string
@@ -73,6 +75,7 @@ export class PocketRelayer {
     checkDebug: boolean
     altruists: string
     aatPlan: string
+    defaultLogLimitBlocks: number
   }) {
     this.host = host
     this.origin = origin
@@ -90,6 +93,7 @@ export class PocketRelayer {
     this.blockchainsRepository = blockchainsRepository
     this.checkDebug = checkDebug
     this.aatPlan = aatPlan
+    this.defaultLogLimitBlocks = defaultLogLimitBlocks
 
     // Create the array of altruist relayers as last resort
     this.altruists = JSON.parse(altruists)
@@ -618,7 +622,8 @@ export class PocketRelayer {
       let blockchainSyncAllowance = 0
       let blockchainIDCheck = ''
       let blockchainID = ''
-      let blockchainLogLimitBlocks = 0
+      // Should never be 0
+      let blockchainLogLimitBlocks = 10000
       const blockchain = blockchainFilter[0].hash as string
 
       // Record the necessary format for the result; example: JSON
@@ -642,9 +647,11 @@ export class PocketRelayer {
       if (blockchainFilter[0].syncAllowance) {
         blockchainSyncAllowance = parseInt(blockchainFilter[0].syncAllowance)
       }
-      // Max number of blocks to request logs for
+      // Max number of blocks to request logs for, if not available, result to env
       if (blockchainFilter[0].logLimitBlocks) {
         blockchainLogLimitBlocks = parseInt(blockchainFilter[0].logLimitBlocks)
+      } else if (this.defaultLogLimitBlocks > 0) {
+        blockchainLogLimitBlocks = this.defaultLogLimitBlocks
       }
 
       return Promise.resolve({

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -22,6 +22,8 @@ import { LimitError } from '../../src/errors/types'
 
 const DB_ENCRYPTION_KEY = '00000000000000000000000000000000'
 
+const DEFAULT_LOG_LIMIT = 10000
+
 const DEFAULT_HOST = 'eth-mainnet-x'
 
 const BLOCKCHAINS = [
@@ -68,12 +70,12 @@ const BLOCKCHAINS = [
     blockchain: 'eth-mainnet-string',
     active: true,
     nodeCount: 1,
-    logLimitBlocks: 10000,
   },
 ]
 
 const ALTRUISTS = {
   '0021': 'https://user:pass@backups.example.org:18081',
+  '0040': 'https://user:pass@backups.example.org:18081',
 }
 
 const APPLICATION = {
@@ -155,6 +157,7 @@ describe('Pocket relayer service (unit)', () => {
       checkDebug: true,
       altruists: '{}',
       aatPlan: AatPlans.FREEMIUM,
+      defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
     })
   })
 
@@ -256,6 +259,7 @@ describe('Pocket relayer service (unit)', () => {
       checkDebug: true,
       altruists: '{}',
       aatPlan: AatPlans.FREEMIUM,
+      defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
     })
 
     const application = {
@@ -291,6 +295,7 @@ describe('Pocket relayer service (unit)', () => {
       checkDebug: true,
       altruists: '{}',
       aatPlan: AatPlans.FREEMIUM,
+      defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
     })
 
     const isInvalidApp = poktRelayer.checkSecretKey(application as unknown as Applications)
@@ -442,6 +447,7 @@ describe('Pocket relayer service (unit)', () => {
         checkDebug: true,
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -485,6 +491,7 @@ describe('Pocket relayer service (unit)', () => {
         checkDebug: true,
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -526,6 +533,7 @@ describe('Pocket relayer service (unit)', () => {
         checkDebug: true,
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -568,6 +576,7 @@ describe('Pocket relayer service (unit)', () => {
         checkDebug: true,
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -611,6 +620,7 @@ describe('Pocket relayer service (unit)', () => {
         checkDebug: true,
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -654,6 +664,7 @@ describe('Pocket relayer service (unit)', () => {
         checkDebug: true,
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -698,6 +709,7 @@ describe('Pocket relayer service (unit)', () => {
         checkDebug: true,
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
       rawData =
@@ -743,6 +755,7 @@ describe('Pocket relayer service (unit)', () => {
         checkDebug: true,
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
       rawData =
@@ -794,6 +807,7 @@ describe('Pocket relayer service (unit)', () => {
         checkDebug: true,
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -843,6 +857,7 @@ describe('Pocket relayer service (unit)', () => {
           checkDebug: true,
           altruists: '{}',
           aatPlan: AatPlans.FREEMIUM,
+          defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
         })
 
         try {
@@ -896,6 +911,7 @@ describe('Pocket relayer service (unit)', () => {
           checkDebug: true,
           altruists: '{}',
           aatPlan: AatPlans.FREEMIUM,
+          defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
         })
 
         try {
@@ -948,6 +964,7 @@ describe('Pocket relayer service (unit)', () => {
           checkDebug: true,
           altruists: '{}',
           aatPlan: AatPlans.FREEMIUM,
+          defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
         })
 
         try {
@@ -1003,6 +1020,7 @@ describe('Pocket relayer service (unit)', () => {
           checkDebug: true,
           altruists: JSON.stringify(ALTRUISTS),
           aatPlan: AatPlans.FREEMIUM,
+          defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
         }) as PocketRelayer
 
         return poktRelayer
@@ -1150,6 +1168,63 @@ describe('Pocket relayer service (unit)', () => {
         })
 
         expect(relayResponse).to.be.deepEqual(JSON.parse(mockRelayResponse as string))
+      })
+
+      it('should succeed if `eth_getLogs` call is within permitted blocks range (using latest) even with not default value set on db or environment', async () => {
+        const blockNumberRespose = {
+          jsonrpc: '2.0',
+          id: 1,
+          result: '0x9c5bb8',
+        }
+
+        const mockRelayResponse =
+          '{"jsonrpc":"2.0","id":1,"result":[{"address":"0xdef1c0ded9bec7f1a1670819833240f027b25eff","blockHash":"0x2ad90e24266edd835bb03071c0c0b58ee8356c2feb4576d15b3c2c2b2ef319c5","blockNumber":"0xc5bdc9","data":"0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2000000000000000000000000767fe9edc9e0df98e07454847909b5e959d7ca0e0000000000000000000000000000000000000000000000019274b259f653fc110000000000000000000000000000000000000000000000104bf2ffa4dcbf8de5","logIndex":"0x4c","removed":false,"topics":["0x0f6672f78a59ba8e5e5b5d38df3ebc67f3c792e2c9259b8d97d7f00dd78ba1b3","0x000000000000000000000000e5feeac09d36b18b3fa757e5cf3f8da6b8e27f4c"],"transactionHash":"0x14430f1e344b5f95ea68a5f4c0538fc732cc97efdc68f6ee0ba20e2c633542f6","transactionIndex":"0x1a"}]}'
+
+        rawData =
+          '{"method":"eth_getLogs","params":[{"fromBlock":"0x9c5bb6","address":"0xdef1c0ded9bec7f1a1670819833240f027b25eff"}],"id":1,"jsonrpc":"2.0"}'
+
+        const pocket = pocketMock.object()
+
+        if (mockRelayResponse) {
+          pocketMock.relayResponse[rawData] = mockRelayResponse
+        }
+
+        axiosMock.onPost(ALTRUISTS['0040'], blockNumberData).reply(200, blockNumberRespose)
+        axiosMock.onPost(ALTRUISTS['0040'], JSON.parse(rawData)).reply(200, mockRelayResponse)
+
+        const poktRelayer = new PocketRelayer({
+          host: 'eth-mainnet-string',
+          origin: '',
+          userAgent: '',
+          pocket,
+          pocketConfiguration,
+          cherryPicker,
+          metricsRecorder,
+          syncChecker,
+          chainChecker,
+          redis,
+          databaseEncryptionKey: DB_ENCRYPTION_KEY,
+          secretKey: '',
+          relayRetries: 0,
+          blockchainsRepository: blockchainRepository,
+          checkDebug: true,
+          altruists: JSON.stringify(ALTRUISTS),
+          aatPlan: AatPlans.FREEMIUM,
+          defaultLogLimitBlocks: 0,
+        }) as PocketRelayer
+
+        const relayResponse = await poktRelayer.sendRelay({
+          rawData,
+          relayPath: '',
+          httpMethod: HTTPMethod.POST,
+          application: APPLICATION as unknown as Applications,
+          requestID: '1234',
+          requestTimeOut: undefined,
+          overallTimeOut: undefined,
+          relayRetries: 0,
+        })
+
+        expect(JSON.parse(relayResponse as string)).to.be.deepEqual(JSON.parse(mockRelayResponse as string))
       })
     })
   })


### PR DESCRIPTION
Log limit of `eth_getlogs` call should never be 0 even in the unlikely case they're not set either on the db or environment variables. Also lowers the default max dispatchers to 24