### PR TITLE
fix: use blockchainID instead of blockchain for Logger

### DIFF
--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -97,6 +97,7 @@ export class ChainChecker {
             serviceNode: nodeChainLog.node.publicKey,
             error: '',
             elapsedTime: '',
+            blockchainID: nodeChainLog.chainID,
           }
         )
 
@@ -114,6 +115,7 @@ export class ChainChecker {
             serviceNode: nodeChainLog.node.publicKey,
             error: '',
             elapsedTime: '',
+            blockchainID: nodeChainLog.chainID,
           }
         )
       }
@@ -229,6 +231,7 @@ export class ChainChecker {
       serviceNode: node.publicKey,
       error: '',
       elapsedTime: '',
+      blockchainID: blockchain,
     })
 
     // Pull the current block from each node using the blockchain's chainCheck as the relay
@@ -263,6 +266,7 @@ export class ChainChecker {
         serviceNode: node.publicKey,
         error: '',
         elapsedTime: '',
+        blockchainID: blockchain,
       })
 
       // Success
@@ -275,6 +279,7 @@ export class ChainChecker {
         serviceNode: node.publicKey,
         error: '',
         elapsedTime: '',
+        blockchainID: blockchain,
       })
 
       let error = relayResponse.message
@@ -282,6 +287,7 @@ export class ChainChecker {
       if (typeof relayResponse.message === 'object') {
         error = JSON.stringify(relayResponse.message)
       }
+
       await this.metricsRecorder.recordMetric({
         requestID: requestID,
         applicationID: applicationID,
@@ -296,6 +302,7 @@ export class ChainChecker {
         method: 'chaincheck',
         error,
         origin: 'chaincheck',
+        blockchainID: blockchain,
       })
     } else {
       logger.log('error', 'CHAIN CHECK ERROR UNHANDLED: ' + JSON.stringify(relayResponse), {
@@ -321,6 +328,7 @@ export class ChainChecker {
         method: 'chaincheck',
         error: JSON.stringify(relayResponse),
         origin: 'chaincheck',
+        blockchainID: blockchain,
       })
     }
     // Failed

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -17,7 +17,7 @@ interface Log {
   serviceNode: string
   error: string | undefined
   elapsedTime: number
-  blockchain: string
+  blockchainID: string
   origin: string
 }
 
@@ -34,8 +34,8 @@ const timestampUTC = () => {
 }
 
 const consoleFormat = printf(
-  ({ level, message, requestID, relayType, typeID, serviceNode, error, elapsedTime, blockchain, origin }: Log) => {
-    return `[${timestampUTC()}] [${level}] [${requestID}] [${relayType}] [${typeID}] [${serviceNode}] [${error}] [${elapsedTime}] [${blockchain}] [${origin}] ${message}`
+  ({ level, message, requestID, relayType, typeID, serviceNode, error, elapsedTime, blockchainID, origin }: Log) => {
+    return `[${timestampUTC()}] [${level}] [${requestID}] [${relayType}] [${typeID}] [${serviceNode}] [${error}] [${elapsedTime}] [${blockchainID}] [${origin}] ${message}`
   }
 )
 

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -70,6 +70,7 @@ export class MetricsRecorder {
     method,
     error,
     origin,
+    blockchainID,
   }: {
     requestID: string
     applicationID: string
@@ -84,6 +85,7 @@ export class MetricsRecorder {
     method: string | undefined
     error: string | undefined
     origin: string | undefined
+    blockchainID: string | undefined
   }): Promise<void> {
     try {
       let elapsedTime = 0
@@ -106,6 +108,7 @@ export class MetricsRecorder {
           elapsedTime,
           error: undefined,
           origin,
+          blockchainID,
         })
       } else if (result === 500) {
         logger.log('error', 'FAILURE' + fallbackTag, {
@@ -116,6 +119,7 @@ export class MetricsRecorder {
           elapsedTime,
           error,
           origin,
+          blockchainID,
         })
       } else if (result === 503) {
         logger.log('error', 'INVALID RESPONSE' + fallbackTag, {
@@ -126,6 +130,7 @@ export class MetricsRecorder {
           elapsedTime,
           error,
           origin,
+          blockchainID,
         })
       }
 
@@ -153,7 +158,7 @@ export class MetricsRecorder {
         .tag('nodePublicKey', serviceNode)
         .tag('method', method)
         .tag('result', result.toString())
-        .tag('blockchain', blockchain)
+        .tag('blockchainID', blockchainID)
         .tag('origin', origin)
         .floatField('bytes', bytes)
         .floatField('elapsedTime', elapsedTime.toFixed(4))

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -203,6 +203,7 @@ export class PocketRelayer {
           method: method,
           error: undefined,
           origin: this.origin,
+          blockchainID,
         })
 
         // Clear error log
@@ -245,6 +246,7 @@ export class PocketRelayer {
           method,
           error,
           origin: this.origin,
+          blockchainID,
         })
       }
     }
@@ -306,6 +308,7 @@ export class PocketRelayer {
             method: method,
             error: undefined,
             origin: this.origin,
+            blockchainID,
           })
 
           // If return payload is valid JSON, turn it into an object so it is sent with content-type: json
@@ -506,6 +509,7 @@ export class PocketRelayer {
             method,
             error,
             origin: this.origin,
+            blockchainID,
           })
           return new Error('Sync / chain check failure; using fallbacks')
         }

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -225,6 +225,7 @@ export class SyncChecker {
           method: 'synccheck',
           error: `OUT OF SYNC: current block height on chain ${blockchain}: ${currentBlockHeight} altruist block height: ${altruistBlockHeight} nodes height: ${nodeSyncLog.blockHeight} sync allowance: ${syncAllowance}`,
           origin: 'synccheck',
+          blockchainID: '',
         })
       }
     }
@@ -445,6 +446,7 @@ export class SyncChecker {
         method: 'synccheck',
         error,
         origin: 'synccheck',
+        blockchainID: '',
       })
     } else {
       logger.log('error', 'SYNC CHECK ERROR UNHANDLED: ' + JSON.stringify(relayResponse), {
@@ -470,6 +472,7 @@ export class SyncChecker {
         method: 'synccheck',
         error: JSON.stringify(relayResponse),
         origin: 'synccheck',
+        blockchainID: '',
       })
     }
     // Failed


### PR DESCRIPTION
PR #242 introduced field `blockchain` for logging instead of `blockchainID`