### PR TITLE
fix: consider there is a 'staging' environment now

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -185,7 +185,7 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
     }
     const psqlConfig = {
       connectionString: psqlConnection,
-      ssl: environment === 'production' ? true : false,
+      ssl: environment === 'production' || environment === 'staging' ? true : false,
     }
     const pgPool = new pg.Pool(psqlConfig)
 

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -95,7 +95,7 @@ const options = {
 const getTransports = () => {
   const transports = [new winstonTransports.Console(options.console)]
 
-  if (environment === 'production' && logToCloudWatch) {
+  if (environment === 'production' || (environment === 'staging' && logToCloudWatch)) {
     if (!accessKeyID) {
       throw new HttpErrors.InternalServerError('AWS_ACCESS_KEY_ID required in ENV')
     }

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -95,7 +95,7 @@ const options = {
 const getTransports = () => {
   const transports = [new winstonTransports.Console(options.console)]
 
-  if (environment === 'production' || (environment === 'staging' && logToCloudWatch)) {
+  if ((environment === 'production' || environment === 'staging') && logToCloudWatch) {
     if (!accessKeyID) {
       throw new HttpErrors.InternalServerError('AWS_ACCESS_KEY_ID required in ENV')
     }


### PR DESCRIPTION
We now need to have a 'staging' environment rather than using 'production' environment on staging to mimic production. The flag for the deployment has been added, this PR updates all the places where this variable was being used and adds support for this new 'staging' environment.