### PR TITLE
Typo on region name env

### DIFF
--- a/.github/workflows/production-ap-southeast-1.yml
+++ b/.github/workflows/production-ap-southeast-1.yml
@@ -44,8 +44,8 @@ jobs:
           envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: 'premium'
           envkey_NODE_ENV: 'production'
-          envkey_REGION: 'ap-se-1'
-          envkey_REGION_NAME: 'ap-se-1'
+          envkey_REGION: 'ap-southeast-1'
+          envkey_REGION_NAME: 'ap-southeast-1'
           envkey_INFLUX_URL: 'https://influx.portal.pokt.network:8086'
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}


### PR DESCRIPTION
typo on region deployments name, causing error when logging on service provider