### PR TITLE
Feat: Cache overruning session nodes stake

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,6 @@ module.exports = {
     curly: 'error',
     'brace-style': ['error', '1tbs'],
     'object-curly-spacing': ['error', 'always'],
-    'function-call-argument-newline': ['error', 'consistent'],
     'one-var-declaration-per-line': ['error', 'always'],
     'import/no-named-as-default-member': 'off',
     'import/no-named-as-default': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4048,6 +4048,11 @@
         "@ethersproject/wordlists": "5.4.0"
       }
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "events": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
@@ -7185,6 +7190,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+    },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
     },
     "p-timeout": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "ioredis": "^4.16.3",
     "log-timestamp": "^0.3.0",
     "loopback-connector-mongodb": "^6.0.0",
+    "p-queue": "^6.6.2",
     "pg": "^8.2.1",
     "pg-format": "^1.0.4",
     "s3-streamlogger": "^1.7.0",

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -25,3 +25,5 @@ export class LimitError extends Error {
     this.method = method
   }
 }
+
+export const MAX_RELAYS_ERROR = 'the evidence is sealed, either max relays reached or claim already submitted'

--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -151,7 +151,7 @@ export class ChainChecker {
         chainCheck,
         blockchainID,
         pocketAAT,
-        this.updateConfigurationConsensus(pocketConfiguration, nodes.length),
+        this.updateConfigurationConsensus(pocketConfiguration),
         undefined,
         'POST' as HTTPMethod,
         undefined,
@@ -357,11 +357,11 @@ export class ChainChecker {
     return nodeChainLog
   }
 
-  updateConfigurationConsensus(pocketConfiguration: Configuration, consensusNodeCount: number): Configuration {
+  updateConfigurationConsensus(pocketConfiguration: Configuration): Configuration {
     return new Configuration(
       pocketConfiguration.maxDispatchers,
       pocketConfiguration.maxSessions,
-      consensusNodeCount,
+      5,
       2000,
       false,
       pocketConfiguration.sessionBlockFrequency,
@@ -402,7 +402,7 @@ interface BaseChainLogOptions {
   pocket: Pocket
   pocketAAT: PocketAAT
   pocketConfiguration: Configuration
-  sessionKey?: string
+  sessionKey: string
 }
 
 interface GetNodesChainLogsOptions extends BaseChainLogOptions {
@@ -424,5 +424,5 @@ export type ChainIDFilterOptions = {
   applicationPublicKey: string
   pocketAAT: PocketAAT
   pocketConfiguration: Configuration
-  sessionKey?: string
+  sessionKey: string
 }

--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -218,7 +218,7 @@ export class ChainChecker {
       await Promise.all(promiseStack)
 
     for (const rawNodeChainLog of rawNodeChainLogs) {
-      if (typeof rawNodeChainLog === 'object' && (rawNodeChainLog.chainID as unknown as string) !== '') {
+      if (typeof rawNodeChainLog === 'object' && (rawNodeChainLog?.chainID as unknown as string) !== '') {
         nodeChainLogs.push(rawNodeChainLog)
       }
     }

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -450,7 +450,7 @@ export class PocketRelayer {
 
         nodes = nodes.filter((n) => !nodesToRemove.includes(n.publicKey))
       } else {
-        await this.redis.set(`session-${sessionKey}`, JSON.stringify([]), 'EX', 7200) // 2 hours
+        await this.redis.set(`session-${sessionKey}`, JSON.stringify([]), 'EX', 60 * 60 * 2) // 2 hours
       }
 
       if (nodes.length === 0) {
@@ -476,7 +476,7 @@ export class PocketRelayer {
         chainCheckPromise = this.chainChecker.chainIDFilter(chainIDOptions)
       }
 
-      if (blockchainSyncCheck && nodes.length >= 3) {
+      if (blockchainSyncCheck) {
         // Check Sync
         const consensusFilterOptions: ConsensusFilterOptions = {
           nodes,

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -272,7 +272,7 @@ export class SyncChecker {
         syncCheck,
         blockchainID,
         pocketAAT,
-        this.updateConfigurationConsensus(pocketConfiguration, nodes.length),
+        this.updateConfigurationConsensus(pocketConfiguration),
         undefined,
         'POST' as HTTPMethod,
         undefined,
@@ -338,7 +338,7 @@ export class SyncChecker {
     pocket: Pocket,
     pocketAAT: PocketAAT,
     pocketConfiguration: Configuration,
-    sessionKey?: string
+    sessionKey: string
   ): Promise<NodeSyncLog[]> {
     const nodeSyncLogs: NodeSyncLog[] = []
     const promiseStack: Promise<NodeSyncLog>[] = []
@@ -392,7 +392,7 @@ export class SyncChecker {
     pocket: Pocket,
     pocketAAT: PocketAAT,
     pocketConfiguration: Configuration,
-    sessionKey?: string
+    sessionKey: string
   ): Promise<NodeSyncLog> {
     logger.log('info', 'SYNC CHECK START', {
       requestID: requestID,
@@ -523,11 +523,11 @@ export class SyncChecker {
     return nodeSyncLog
   }
 
-  updateConfigurationConsensus(pocketConfiguration: Configuration, consensusNodeCount: number): Configuration {
+  updateConfigurationConsensus(pocketConfiguration: Configuration): Configuration {
     return new Configuration(
       pocketConfiguration.maxDispatchers,
       pocketConfiguration.maxSessions,
-      consensusNodeCount,
+      5,
       2000,
       false,
       pocketConfiguration.sessionBlockFrequency,
@@ -573,5 +573,5 @@ export type ConsensusFilterOptions = {
   pocket: Pocket
   pocketAAT: PocketAAT
   pocketConfiguration: Configuration
-  sessionKey?: string
+  sessionKey: string
 }

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -97,7 +97,7 @@ export class SyncChecker {
     let errorState = false
 
     // This should never happen
-    if (nodeSyncLogs.length <= 2) {
+    if (nodes.length > 2 && nodeSyncLogs.length <= 2) {
       logger.log('error', 'SYNC CHECK ERROR: fewer than 3 nodes returned sync', {
         requestID: requestID,
         relayType: '',
@@ -138,8 +138,13 @@ export class SyncChecker {
       currentBlockHeight = nodeSyncLogs[0].blockHeight
     }
 
-    // Make sure at least 2 nodes agree on current highest block to prevent one node from being wildly off
-    if (!errorState && nodeSyncLogs[0].blockHeight > nodeSyncLogs[1].blockHeight + syncAllowance) {
+    // If there's at least 2 nodes, make sure at least two of them agree on current highest block to prevent one node
+    // from being wildly off
+    if (
+      !errorState &&
+      nodeSyncLogs.length >= 2 &&
+      nodeSyncLogs[0].blockHeight > nodeSyncLogs[1].blockHeight + syncAllowance
+    ) {
       logger.log('error', 'SYNC CHECK ERROR: two highest nodes could not agree on sync', {
         requestID: requestID,
         relayType: '',
@@ -374,7 +379,7 @@ export class SyncChecker {
       await Promise.all(promiseStack)
 
     for (const rawNodeSyncLog of rawNodeSyncLogs) {
-      if (typeof rawNodeSyncLog === 'object') {
+      if (typeof rawNodeSyncLog === 'object' && rawNodeSyncLog?.blockHeight > 0) {
         nodeSyncLogs.push(rawNodeSyncLog)
       }
     }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,6 +1,10 @@
 import { Node } from '@pokt-network/pocket-js'
 import { Redis } from 'ioredis'
+import PQueue from 'p-queue'
+
 const logger = require('../services/logger')
+
+const queue = new PQueue({ concurrency: 1 })
 
 /**
  * Removes node from cached session, following calls within the same session
@@ -11,21 +15,30 @@ const logger = require('../services/logger')
  * @returns
  */
 export async function removeNodeFromSession(redis: Redis, sessionKey: string, node: Node): Promise<void> {
-  const cachedNodes = await redis.get(`session-${sessionKey}`)
+  const operation = async () => {
+    const cachedNodes = await redis.get(`session-${sessionKey}`)
 
-  // This should not happen as session cache should be created on pocket-relayer
-  // service before using this function, usage of this function outside relaying
-  // context does not make sense, won't have any effect and is thereby discouraged
-  if (!cachedNodes) {
-    logger.log(
-      'warn',
-      `attempting to remove node from uncached session. SessionKey: ${sessionKey}, node public key: ${node.publicKey}`
-    )
-    return
+    // This should not happen as session cache should be created on pocket-relayer
+    // service before using this function, usage of this function outside relaying
+    // context does not make sense, won't have any effect and is thereby discouraged
+    if (!cachedNodes) {
+      logger.log(
+        'warn',
+        `attempting to remove node from uncached session. SessionKey: ${sessionKey}, node public key: ${node.publicKey}`
+      )
+      return
+    }
+
+    const nodes: string[] = JSON.parse(cachedNodes)
+
+    if (nodes.includes(node.publicKey)) {
+      return
+    }
+
+    nodes.push(node.publicKey)
+    await redis.set(`session-${sessionKey}`, JSON.stringify(nodes), 'KEEPTTL')
   }
 
-  const nodes: string[] = JSON.parse(cachedNodes)
-
-  nodes.push(node.publicKey)
-  await redis.set(`session-${sessionKey}`, JSON.stringify(nodes), 'KEEPTTL')
+  // Prevent write clashes in case multiple nodes fail at the same time
+  await queue.add(() => operation())
 }

--- a/tests/unit/chain-checker.unit.ts
+++ b/tests/unit/chain-checker.unit.ts
@@ -57,7 +57,7 @@ describe('Chain checker service (unit)', () => {
   it('updates the configuration consensus to one already set', () => {
     const configuration = getPocketConfigOrDefault({ consensusNodeCount: 9 })
     const expectedConsensusCount = 5
-    const newConfig = chainChecker.updateConfigurationConsensus(configuration, 5)
+    const newConfig = chainChecker.updateConfigurationConsensus(configuration)
 
     expect(newConfig.consensusNodeCount).to.be.equal(expectedConsensusCount)
   })
@@ -89,6 +89,7 @@ describe('Chain checker service (unit)', () => {
         applicationPublicKey: '',
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
       })
 
       const expectedChainID = 100 // 0x64 to base 10
@@ -113,6 +114,7 @@ describe('Chain checker service (unit)', () => {
         applicationPublicKey: '',
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
       })
 
       const expectedChainID = 0
@@ -138,6 +140,7 @@ describe('Chain checker service (unit)', () => {
         applicationPublicKey: '',
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
       })
 
       const expectedChainID = 0
@@ -168,6 +171,7 @@ describe('Chain checker service (unit)', () => {
       applicationPublicKey: '',
       pocketAAT: undefined,
       pocketConfiguration,
+      sessionKey: '',
     })
 
     const expectedChainID = 100 // 0x64 to base 10
@@ -196,6 +200,7 @@ describe('Chain checker service (unit)', () => {
       applicationPublicKey: '',
       pocketAAT: undefined,
       pocketConfiguration,
+      sessionKey: '',
       chainID,
     })
 
@@ -216,6 +221,7 @@ describe('Chain checker service (unit)', () => {
       applicationPublicKey: '',
       pocketAAT: undefined,
       pocketConfiguration,
+      sessionKey: '',
       chainID,
     })
 
@@ -241,6 +247,7 @@ describe('Chain checker service (unit)', () => {
       applicationPublicKey: '',
       pocketAAT: undefined,
       pocketConfiguration,
+      sessionKey: '',
       chainID,
     })
 

--- a/tests/unit/chain-checker.unit.ts
+++ b/tests/unit/chain-checker.unit.ts
@@ -54,7 +54,7 @@ describe('Chain checker service (unit)', () => {
   it('updates the configuration consensus to one already set', () => {
     const configuration = getPocketConfigOrDefault({ consensusNodeCount: 9 })
     const expectedConsensusCount = 5
-    const newConfig = chainChecker.updateConfigurationConsensus(configuration)
+    const newConfig = chainChecker.updateConfigurationConsensus(configuration, 5)
 
     expect(newConfig.consensusNodeCount).to.be.equal(expectedConsensusCount)
   })

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -4,8 +4,7 @@ import RedisMock from 'ioredis-mock'
 import { Encryptor } from 'strong-cryptor'
 import { HttpErrors } from '@loopback/rest'
 import { expect, sinon } from '@loopback/testlab'
-import { HTTPMethod, Configuration, Node } from '@pokt-network/pocket-js'
-
+import { HTTPMethod, Configuration, Node, RpcError, Session } from '@pokt-network/pocket-js'
 import AatPlans from '../../src/config/aat-plans.json'
 import { getPocketConfigOrDefault } from '../../src/config/pocket-config'
 import { ChainChecker, ChainIDFilterOptions } from '../../src/services/chain-checker'
@@ -18,7 +17,7 @@ import { metricsRecorderMock } from '../mocks/metricsRecorder'
 import { DEFAULT_NODES, PocketMock } from '../mocks/pocketjs'
 import { BlockchainsRepository } from '../../src/repositories/blockchains.repository'
 import { gatewayTestDB } from '../fixtures/test.datasource'
-import { LimitError } from '../../src/errors/types'
+import { LimitError, MAX_RELAYS_ERROR } from '../../src/errors/types'
 
 const DB_ENCRYPTION_KEY = '00000000000000000000000000000000'
 
@@ -26,6 +25,7 @@ const DEFAULT_LOG_LIMIT = 10000
 
 const DEFAULT_HOST = 'eth-mainnet-x'
 
+// Properties below might not reflect real-world values
 const BLOCKCHAINS = [
   {
     hash: '0041',
@@ -59,6 +59,7 @@ const BLOCKCHAINS = [
     // Does not actually exist on this chain, only for testing purposes
     syncCheckPath: '/v1/query/height',
     syncAllowance: 2,
+    chainID: 100,
   },
   {
     hash: '0040',
@@ -579,6 +580,89 @@ describe('Pocket relayer service (unit)', () => {
       })
 
       expect(relayResponse).to.be.instanceOf(HttpErrors.GatewayTimeout)
+    })
+
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('Fails relay due to all nodes in session running out of relays, subsequent relays should not attempt to perform checks', async () => {
+      const mock = new PocketMock()
+
+      const maxRelaysError = new RpcError('90', MAX_RELAYS_ERROR)
+
+      mock.relayResponse[BLOCKCHAINS[1].chainIDCheck] = Array(5).fill(maxRelaysError)
+      mock.relayResponse[BLOCKCHAINS[1].syncCheck] = Array(5).fill(maxRelaysError)
+      mock.relayResponse[rawData] = '{"error": "a relay error"}'
+
+      const chainCheckerSpy = sinon.spy(chainChecker, 'chainIDFilter')
+
+      const syncCherckerSpy = sinon.spy(syncChecker, 'consensusFilter')
+
+      const pocket = mock.object()
+
+      const poktRelayer = new PocketRelayer({
+        host: 'eth-mainnet',
+        origin: '',
+        userAgent: '',
+        pocket,
+        pocketConfiguration,
+        cherryPicker,
+        metricsRecorder,
+        syncChecker,
+        chainChecker,
+        redis,
+        databaseEncryptionKey: DB_ENCRYPTION_KEY,
+        secretKey: '',
+        relayRetries: 0,
+        blockchainsRepository: blockchainRepository,
+        checkDebug: true,
+        altruists: '{}',
+        aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+      })
+
+      const relayResponse = await poktRelayer.sendRelay({
+        rawData,
+        relayPath: '',
+        httpMethod: HTTPMethod.POST,
+        application: APPLICATION as unknown as Applications,
+        requestID: '1234',
+        requestTimeOut: undefined,
+        overallTimeOut: undefined,
+        relayRetries: 0,
+      })
+
+      expect(relayResponse).to.be.instanceOf(HttpErrors.GatewayTimeout)
+
+      const sessionKey = ((await pocket.sessionManager.getCurrentSession(undefined, undefined, undefined)) as Session)
+        .sessionKey
+
+      let removedNodes = await redis.get(`session-${sessionKey}`)
+
+      expect(JSON.parse(removedNodes)).to.have.length(5)
+
+      expect(chainCheckerSpy.callCount).to.be.equal(1)
+      expect(syncCherckerSpy.callCount).to.be.equal(1)
+
+      console.log('\n\n LLAMANDO OTRA VE MMG\n\n')
+      // Subsequent calls should not go to sync or chain checker
+      const secondRelayResponse = await poktRelayer.sendRelay({
+        rawData,
+        relayPath: '',
+        httpMethod: HTTPMethod.POST,
+        application: APPLICATION as unknown as Applications,
+        requestID: '1234',
+        requestTimeOut: undefined,
+        overallTimeOut: undefined,
+        relayRetries: 0,
+      })
+
+      expect(secondRelayResponse).to.be.instanceOf(HttpErrors.GatewayTimeout)
+
+      removedNodes = await redis.get(`session-${sessionKey}`)
+
+      expect(JSON.parse(removedNodes)).to.have.length(5)
+
+      expect(chainCheckerSpy.callCount).to.be.equal(1)
+      expect(syncCherckerSpy.callCount).to.be.equal(1)
     })
 
     it('chainIDCheck / syncCheck succeeds', async () => {

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -582,8 +582,7 @@ describe('Pocket relayer service (unit)', () => {
       expect(relayResponse).to.be.instanceOf(HttpErrors.GatewayTimeout)
     })
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('Fails relay due to all nodes in session running out of relays, subsequent relays should not attempt to perform checks', async () => {
+    it('Fails relay due to all nodes in session running out of relays, subsequent relays should not attempt to perform checks', async () => {
       const mock = new PocketMock()
 
       const maxRelaysError = new RpcError('90', MAX_RELAYS_ERROR)
@@ -642,7 +641,6 @@ describe('Pocket relayer service (unit)', () => {
       expect(chainCheckerSpy.callCount).to.be.equal(1)
       expect(syncCherckerSpy.callCount).to.be.equal(1)
 
-      console.log('\n\n LLAMANDO OTRA VE MMG\n\n')
       // Subsequent calls should not go to sync or chain checker
       const secondRelayResponse = await poktRelayer.sendRelay({
         rawData,

--- a/tests/unit/sync-checker.unit.ts
+++ b/tests/unit/sync-checker.unit.ts
@@ -78,7 +78,7 @@ describe('Sync checker service (unit)', () => {
 
     const expectedConsensusCount = 5
 
-    const newConfig = syncChecker.updateConfigurationConsensus(configuration, 5)
+    const newConfig = syncChecker.updateConfigurationConsensus(configuration)
 
     expect(newConfig.consensusNodeCount).to.be.equal(expectedConsensusCount)
   })
@@ -109,7 +109,8 @@ describe('Sync checker service (unit)', () => {
         '',
         pocket,
         undefined,
-        pocketConfiguration
+        pocketConfiguration,
+        ''
       )
 
       const expectedBlockHeight = 17435804 // 0x10a0c9c to base 10
@@ -136,7 +137,8 @@ describe('Sync checker service (unit)', () => {
         '',
         pocket,
         undefined,
-        pocketConfiguration
+        pocketConfiguration,
+        ''
       )
 
       const expectedBlockHeight = 0
@@ -164,7 +166,8 @@ describe('Sync checker service (unit)', () => {
         '',
         pocket,
         undefined,
-        pocketConfiguration
+        pocketConfiguration,
+        ''
       )
 
       const expectedBlockHeight = 0
@@ -212,7 +215,8 @@ describe('Sync checker service (unit)', () => {
       '',
       pocketClient,
       undefined,
-      pocketConfiguration
+      pocketConfiguration,
+      ''
     )
 
     const expectedBlockHeight = 17435804 // 0x10a0c9c to base 10
@@ -245,6 +249,7 @@ describe('Sync checker service (unit)', () => {
         blockchainSyncBackup: ALTRUIST_URL,
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
         syncAllowance: SYNC_ALLOWANCE,
         syncCheckPath: '',
       })
@@ -266,6 +271,7 @@ describe('Sync checker service (unit)', () => {
         blockchainSyncBackup: ALTRUIST_URL,
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
         syncAllowance: SYNC_ALLOWANCE,
         syncCheckPath: '',
       })
@@ -294,6 +300,7 @@ describe('Sync checker service (unit)', () => {
         blockchainSyncBackup: ALTRUIST_URL,
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
         syncAllowance: SYNC_ALLOWANCE,
         syncCheckPath: '',
       })
@@ -328,6 +335,7 @@ describe('Sync checker service (unit)', () => {
         blockchainSyncBackup: ALTRUIST_URL,
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
         syncAllowance: SYNC_ALLOWANCE,
         syncCheckPath: '',
       })
@@ -353,6 +361,7 @@ describe('Sync checker service (unit)', () => {
         blockchainSyncBackup: ALTRUIST_URL,
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
         syncAllowance: SYNC_ALLOWANCE,
         syncCheckPath: '',
       })
@@ -388,6 +397,7 @@ describe('Sync checker service (unit)', () => {
         blockchainSyncBackup: ALTRUIST_URL,
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
         syncAllowance: SYNC_ALLOWANCE,
         syncCheckPath: '',
       })
@@ -433,6 +443,7 @@ describe('Sync checker service (unit)', () => {
         blockchainSyncBackup: ALTRUIST_URL,
         pocketAAT: undefined,
         pocketConfiguration,
+        sessionKey: '',
         syncAllowance: SYNC_ALLOWANCE,
         syncCheckPath: '',
       })

--- a/tests/unit/sync-checker.unit.ts
+++ b/tests/unit/sync-checker.unit.ts
@@ -77,7 +77,7 @@ describe('Sync checker service (unit)', () => {
 
     const expectedConsensusCount = 5
 
-    const newConfig = syncChecker.updateConfigurationConsensus(configuration)
+    const newConfig = syncChecker.updateConfigurationConsensus(configuration, 5)
 
     expect(newConfig.consensusNodeCount).to.be.equal(expectedConsensusCount)
   })


### PR DESCRIPTION
Closes #262. This adds another cache layer to session nodes, now, when a session is created/obtained, a cache is created for ~~the maximum time of the session as set on the pocket configuration~~ two hours. From there on, if within a session a node fails due to overruning their max stake, it will be added to the session's cache and won't be include in future checks (sync and chain check), if a session has no nodes left, it will directly go to the altruists.

This change adds some important changes to take into consideration:

1. On sync check, when penalizing nodes out of sync, is based on the number of nodes available, not 5 nodes as it previously was
2. On chain check, when penalizing nodes reporting incorrect data, is based on the number of nodes available, not 5 nodes as it previously was
3. ~~Sync check only occurs now if there's at least 3 nodes available~~. No longer true

Besides that, no other major change was added, but feel free to comment on desired/expected behaviors from this.