### PR TITLE
Reset cache on exhaust

### DIFF
--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -3,6 +3,7 @@ import { MetricsRecorder } from '../services/metrics-recorder'
 import { Redis } from 'ioredis'
 import { blockHexToDecimal, checkEnforcementJSON } from '../utils'
 import { MAX_RELAYS_ERROR } from '../errors/types'
+import { removeNodeFromSession } from '../utils/cache'
 
 const logger = require('../services/logger')
 
@@ -279,7 +280,7 @@ export class ChainChecker {
       let error = relayResponse.message
 
       if (error === MAX_RELAYS_ERROR) {
-        await this.redis.sadd(`session-${sessionKey}`, node.publicKey)
+        await removeNodeFromSession(this.redis, sessionKey, node.publicKey)
       }
 
       if (typeof relayResponse.message === 'object') {

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -17,6 +17,7 @@ import { JSONObject } from '@loopback/context'
 const logger = require('../services/logger')
 
 import axios from 'axios'
+import { removeNodeFromSession } from '../utils/cache'
 
 export class PocketRelayer {
   host: string
@@ -634,7 +635,7 @@ export class PocketRelayer {
     } else if (relayResponse instanceof Error) {
       // Remove node from session if error is due to max relays allowed reached
       if (relayResponse.message === MAX_RELAYS_ERROR) {
-        await this.redis.sadd(`session-${(pocketSession as Session).sessionKey}`, node.publicKey)
+        await removeNodeFromSession(this.redis, (pocketSession as Session).sessionKey, node.publicKey)
       }
 
       return new RelayError(relayResponse.message, 500, node?.publicKey)

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -7,6 +7,7 @@ const logger = require('../services/logger')
 
 import axios from 'axios'
 import { MAX_RELAYS_ERROR } from '../errors/types'
+import { removeNodeFromSession } from '../utils/cache'
 
 export class SyncChecker {
   redis: Redis
@@ -447,7 +448,7 @@ export class SyncChecker {
       let error = relayResponse.message
 
       if (error === MAX_RELAYS_ERROR) {
-        await this.redis.sadd(`session-${sessionKey}`, node.publicKey)
+        await removeNodeFromSession(this.redis, sessionKey, node.publicKey)
       }
 
       if (typeof relayResponse.message === 'object') {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,16 @@
+import { Redis } from 'ioredis'
+
+/**
+ * Removes node from cached session, following calls within the same session,
+ * also cleans the chain/sync check cache
+ * should not be used
+ * @param redis cache service to use
+ * @param sessionKey session key
+ * @param nodePubKey node to remove's public key
+ * @returns
+ */
+export async function removeNodeFromSession(redis: Redis, sessionKey: string, nodePubKey: string): Promise<void> {
+  await redis.sadd(`session-${sessionKey}`, nodePubKey)
+
+  await redis.del(`sync-check-${sessionKey}`, `chain-check-${sessionKey}`)
+}

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -665,6 +665,82 @@ describe('Pocket relayer service (unit)', () => {
       expect(syncCherckerSpy.callCount).to.be.equal(1)
     })
 
+    it('Fails relay due to one node in session running out of relays, subsequent relays should attempt to perform checks', async () => {
+      const mock = new PocketMock()
+
+      mock.relayResponse[rawData] = new RpcError('90', MAX_RELAYS_ERROR)
+
+      const { chainChecker: mockChainChecker, syncChecker: mockSyncChecker } = mockChainAndSyncChecker(5, 5)
+      const chainCheckerSpy = sinon.spy(chainChecker, 'chainIDFilter')
+      const syncCherckerSpy = sinon.spy(syncChecker, 'consensusFilter')
+      const pocket = mock.object()
+
+      const poktRelayer = new PocketRelayer({
+        host: 'eth-mainnet',
+        origin: '',
+        userAgent: '',
+        pocket,
+        pocketConfiguration,
+        cherryPicker,
+        metricsRecorder,
+        syncChecker: mockSyncChecker,
+        chainChecker: mockChainChecker,
+        redis,
+        databaseEncryptionKey: DB_ENCRYPTION_KEY,
+        secretKey: '',
+        relayRetries: 0,
+        blockchainsRepository: blockchainRepository,
+        checkDebug: true,
+        altruists: '{}',
+        aatPlan: AatPlans.FREEMIUM,
+        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+      })
+
+      const relayResponse = await poktRelayer.sendRelay({
+        rawData,
+        relayPath: '',
+        httpMethod: HTTPMethod.POST,
+        application: APPLICATION as unknown as Applications,
+        requestID: '1234',
+        requestTimeOut: undefined,
+        overallTimeOut: undefined,
+        relayRetries: 0,
+      })
+
+      expect(relayResponse).to.be.instanceOf(HttpErrors.GatewayTimeout)
+
+      const sessionKey = ((await pocket.sessionManager.getCurrentSession(undefined, undefined, undefined)) as Session)
+        .sessionKey
+
+      let removedNodes = await redis.smembers(`session-${sessionKey}`)
+
+      expect(removedNodes).to.have.length(1)
+
+      expect(chainCheckerSpy.callCount).to.be.equal(1)
+      expect(syncCherckerSpy.callCount).to.be.equal(1)
+
+      // Subsequent calls should go to sync or chain checker
+      const secondRelayResponse = await poktRelayer.sendRelay({
+        rawData,
+        relayPath: '',
+        httpMethod: HTTPMethod.POST,
+        application: APPLICATION as unknown as Applications,
+        requestID: '1234',
+        requestTimeOut: undefined,
+        overallTimeOut: undefined,
+        relayRetries: 0,
+      })
+
+      expect(secondRelayResponse).to.be.instanceOf(HttpErrors.GatewayTimeout)
+
+      removedNodes = await redis.smembers(`session-${sessionKey}`)
+
+      expect(removedNodes.length).to.have.lessThanOrEqual(2)
+
+      expect(chainCheckerSpy.callCount).to.be.equal(2)
+      expect(syncCherckerSpy.callCount).to.be.equal(2)
+    })
+
     it('chainIDCheck / syncCheck succeeds', async () => {
       const { chainChecker: mockChainChecker, syncChecker: mockSyncChecker } = mockChainAndSyncChecker(5, 5)
 


### PR DESCRIPTION
Once a node is removed, there's a period where it still can be taken on the session, leading to an expected failure following an altruist relay, which is an undesired overheat. This ensures that now everytime a node is removed, upcoming requests will need to do a sync check/chain check to reverify the behavior of remaining nodes