### PR TITLE
fix: block unproperly parsing string numbers

### DIFF
--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -1,7 +1,7 @@
 import { Configuration, HTTPMethod, Node, Pocket, PocketAAT, RelayResponse } from '@pokt-network/pocket-js'
 import { MetricsRecorder } from '../services/metrics-recorder'
 import { Redis } from 'ioredis'
-import { blockHexToDecimal, checkEnforcementJSON, getNodeNetworkData, isBlockHex } from '../utils'
+import { blockHexToDecimal, checkEnforcementJSON, getNodeNetworkData } from '../utils'
 
 const logger = require('../services/logger')
 
@@ -566,7 +566,7 @@ export class SyncChecker {
   parseBlockFromPayload(payload: object, syncCheckResultKey: string): number {
     const rawHeight = payload[`${syncCheckResultKey}`] || '0'
 
-    const blockHeight = isBlockHex(rawHeight) ? blockHexToDecimal(rawHeight) : parseInt(rawHeight)
+    const blockHeight = blockHexToDecimal(rawHeight)
 
     return blockHeight
   }

--- a/src/utils/block.ts
+++ b/src/utils/block.ts
@@ -1,5 +1,5 @@
 export function blockHexToDecimal(hex: string): number {
-  return parseInt(hex, 16)
+  return parseInt(hex)
 }
 
 export function isBlockHex(block: string): boolean {


### PR DESCRIPTION
The function did work for hex strings like `0x53a` but not for valid regular numbers as strings.

`parseInt` with base 16 only works for those hex strings, and `parseInt` with default base works for both. Initially this function only received hex strings from EVM chains, now that we support other non EVM we have to be aware that we won't only receive hex block numbers.