### PR TITLE
fix: cherry picker receiving 0 nodes at certain times

### DIFF
--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -50,6 +50,7 @@ export class CherryPicker {
         relayType: 'LB',
         typeID: loadBalancerID,
         serviceNode: '',
+        blockchainID: blockchain,
       })
       rankedItems = applications
     }
@@ -62,11 +63,13 @@ export class CherryPicker {
         requestID: requestID,
         relayType: 'LB',
         typeID: loadBalancerID,
+        blockchainID: blockchain,
       })
       logger.log('debug', 'Selected ' + selectedApplication + ' : ' + application, {
         requestID: requestID,
         relayType: 'LB',
         typeID: loadBalancerID,
+        blockchainID: blockchain,
       })
     }
     return application
@@ -108,6 +111,7 @@ export class CherryPicker {
         relayType: 'APP',
         typeID: application.id,
         serviceNode: '',
+        blockchainID: blockchain,
       })
       rankedItems = rawNodeIDs
     }
@@ -121,12 +125,14 @@ export class CherryPicker {
         relayType: 'APP',
         typeID: application.id,
         serviceNode: '',
+        blockchainID: blockchain,
       })
       logger.log('debug', 'Selected ' + selectedNode + ' : ' + node.publicKey, {
         requestID: requestID,
         relayType: 'APP',
         typeID: application.id,
         serviceNode: '',
+        blockchainID: blockchain,
       })
     }
     return node

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -583,7 +583,7 @@ export class PocketRelayer {
         if (filteredNodes.length > 0) {
           nodes = filteredNodes
         }
-      } else if (blockchainSyncCheck) {
+      } else if (syncCheckedNodes.length > 0) {
         // For non-EVM chains that only have sync check, like pocket.
         nodes = syncCheckedNodes
       }

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -851,7 +851,6 @@ export class PocketRelayer {
     const nodes = syncCheckNodes.filter((syncCheckNode) =>
       chainCheckedNodes.some((chainCheckedNode) => syncCheckNode.publicKey === chainCheckedNode.publicKey)
     )
-    // If no nodes passed both checks, return sync checked nodes.
 
     return nodes
   }

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -515,72 +515,75 @@ export class PocketRelayer {
 
       const [chainCheckResult, syncCheckResult] = await checkersPromise
 
-      if (blockchainIDCheck) {
-        if (
-          chainCheckResult.status === 'fulfilled' &&
-          chainCheckResult.value !== undefined &&
-          chainCheckResult.value.length > 0
-        ) {
-          chainCheckedNodes = chainCheckResult.value
-        } else {
-          if (chainCheckResult.status === 'rejected') {
-            logger.log('error', `Error while running chain check: ${chainCheckResult.reason}.`, {
-              requestID: requestID,
-              relayType: 'APP',
-              typeID: application.id,
-              serviceNode: '',
-            })
-          }
-          return new Error('ChainID check failure; using fallbacks')
+      if (
+        blockchainIDCheck &&
+        chainCheckResult.status === 'fulfilled' &&
+        chainCheckResult.value !== undefined &&
+        chainCheckResult.value.length > 0
+      ) {
+        chainCheckedNodes = chainCheckResult.value
+      } else {
+        if (chainCheckResult.status === 'rejected') {
+          logger.log('error', `Error while running chain check: ${chainCheckResult.reason}.`, {
+            requestID: requestID,
+            relayType: 'APP',
+            typeID: application.id,
+            serviceNode: '',
+          })
         }
+        return new Error('ChainID check failure; using fallbacks')
       }
 
-      if (blockchainSyncCheck) {
-        if (
-          syncCheckResult.status === 'fulfilled' &&
-          syncCheckResult.value !== undefined &&
-          syncCheckResult.value.length > 0
-        ) {
-          syncCheckedNodes = syncCheckResult.value
-        } else {
-          const error = 'Sync / chain check failure'
-          const method = 'checks'
+      if (
+        blockchainSyncCheck &&
+        syncCheckResult.status === 'fulfilled' &&
+        syncCheckResult.value !== undefined &&
+        syncCheckResult.value.length > 0
+      ) {
+        syncCheckedNodes = syncCheckResult.value
+      } else {
+        const error = 'Sync / chain check failure'
+        const method = 'checks'
 
-          await this.metricsRecorder.recordMetric({
-            requestID,
-            applicationID: application.id,
-            applicationPublicKey: application.gatewayAAT.applicationPublicKey,
-            blockchainID,
-            serviceNode: 'session-failure',
-            relayStart,
-            result: 500,
-            bytes: Buffer.byteLength(error, 'utf8'),
-            delivered: false,
-            fallback: false,
-            method,
-            error,
-            origin: this.origin,
-            data,
-            sessionKey,
+        await this.metricsRecorder.recordMetric({
+          requestID,
+          applicationID: application.id,
+          applicationPublicKey: application.gatewayAAT.applicationPublicKey,
+          blockchainID,
+          serviceNode: 'session-failure',
+          relayStart,
+          result: 500,
+          bytes: Buffer.byteLength(error, 'utf8'),
+          delivered: false,
+          fallback: false,
+          method,
+          error,
+          origin: this.origin,
+          data,
+          sessionKey,
+        })
+
+        if (syncCheckResult.status === 'rejected') {
+          logger.log('error', `Error while running sync check: ${syncCheckResult.reason}.`, {
+            requestID: requestID,
+            relayType: 'APP',
+            typeID: application.id,
+            serviceNode: '',
           })
-
-          if (syncCheckResult.status === 'rejected') {
-            logger.log('error', `Error while running sync check: ${syncCheckResult.reason}.`, {
-              requestID: requestID,
-              relayType: 'APP',
-              typeID: application.id,
-              serviceNode: '',
-            })
-          }
-
-          return new Error('Sync / chain check failure; using fallbacks')
         }
+
+        return new Error('Sync / chain check failure; using fallbacks')
       }
 
       // EVM-chains always have chain/sync checks.
       if (chainCheckedNodes.length > 0 && syncCheckedNodes.length > 0) {
-        nodes = this.filterCheckedNodes(syncCheckedNodes, chainCheckedNodes)
-      } else if (syncCheckedNodes.length > 0) {
+        const filteredNodes = this.filterCheckedNodes(syncCheckedNodes, chainCheckedNodes)
+
+        // There's a chance that no nodes passes both checks.
+        if (filteredNodes.length > 0) {
+          nodes = filteredNodes
+        }
+      } else if (blockchainSyncCheck) {
         // For non-EVM chains that only have sync check, like pocket.
         nodes = syncCheckedNodes
       }
@@ -863,6 +866,7 @@ export class PocketRelayer {
     const nodes = syncCheckNodes.filter((syncCheckNode) =>
       chainCheckedNodes.some((chainCheckedNode) => syncCheckNode.publicKey === chainCheckedNode.publicKey)
     )
+    // If no nodes passed both checks, return sync checked nodes.
 
     return nodes
   }

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -523,14 +523,6 @@ export class PocketRelayer {
       ) {
         chainCheckedNodes = chainCheckResult.value
       } else {
-        if (chainCheckResult.status === 'rejected') {
-          logger.log('error', `Error while running chain check: ${chainCheckResult.reason}.`, {
-            requestID: requestID,
-            relayType: 'APP',
-            typeID: application.id,
-            serviceNode: '',
-          })
-        }
         return new Error('ChainID check failure; using fallbacks')
       }
 
@@ -542,7 +534,7 @@ export class PocketRelayer {
       ) {
         syncCheckedNodes = syncCheckResult.value
       } else {
-        const error = 'Sync / chain check failure'
+        const error = 'Sync check failure'
         const method = 'checks'
 
         await this.metricsRecorder.recordMetric({
@@ -563,16 +555,7 @@ export class PocketRelayer {
           sessionKey,
         })
 
-        if (syncCheckResult.status === 'rejected') {
-          logger.log('error', `Error while running sync check: ${syncCheckResult.reason}.`, {
-            requestID: requestID,
-            relayType: 'APP',
-            typeID: application.id,
-            serviceNode: '',
-          })
-        }
-
-        return new Error('Sync / chain check failure; using fallbacks')
+        return new Error('Sync check failure; using fallbacks')
       }
 
       // EVM-chains always have chain/sync checks.
@@ -582,6 +565,8 @@ export class PocketRelayer {
         // There's a chance that no nodes passes both checks.
         if (filteredNodes.length > 0) {
           nodes = filteredNodes
+        } else {
+          return new Error('Sync / chain check failure; using fallbacks')
         }
       } else if (syncCheckedNodes.length > 0) {
         // For non-EVM chains that only have sync check, like pocket.

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -150,7 +150,7 @@ export class PocketRelayer {
 
     if (limitation instanceof Error) {
       logger.log('error', `LIMITATION ERROR ${blockchainID} req: ${data}`, {
-        blockchainID: blockchainID,
+        blockchainID,
         requestID: requestID,
         relayType: 'APP',
         error: `${parsedRawData.method} method limitations exceeded.`,
@@ -578,9 +578,9 @@ export class PocketRelayer {
       }
 
       // EVM-chains always have chain/sync checks.
-      if (blockchainIDCheck && blockchainSyncCheck) {
+      if (chainCheckedNodes.length > 0 && syncCheckedNodes.length > 0) {
         nodes = this.filterCheckedNodes(syncCheckedNodes, chainCheckedNodes)
-      } else if (blockchainSyncCheck) {
+      } else if (syncCheckedNodes.length > 0) {
         // For non-EVM chains that only have sync check, like pocket.
         nodes = syncCheckedNodes
       }

--- a/tests/acceptance/test-helper.ts
+++ b/tests/acceptance/test-helper.ts
@@ -35,7 +35,8 @@ const DUMMY_ENV = {
     "0026": "https://user:pass@backups.example.org:18556",
     "0027": "https://user:pass@backups.example.org:18546",
     "0028": "https://user:pass@backups.example.org:18545",
-    "000A": "https://user:pass@backups.example.org:18553"
+    "000A": "https://user:pass@backups.example.org:18553",
+    "0041": "https://user:pass@backups.example.org:18082"
   }`,
   POCKET_SESSION_BLOCK_FREQUENCY: 4,
   POCKET_BLOCK_TIME: 1038000,

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -192,11 +192,17 @@ describe('V1 controller (acceptance)', () => {
   it('invokes GET /v1/{appId} and successfully relays a request', async () => {
     const pocket = pocketMock.class()
 
+    relayResponses['{"method":"eth_blockNumber","id":1,"jsonrpc":"2.0"}'] =
+      '{"id":1,"jsonrpc":"2.0","result":"0x1083d57"}'
+
+    axiosMock
+      .onPost('https://user:pass@backups.example.org:18082')
+      .reply(200, { id: 1, jsonrpc: '2.0', result: '0x1083d57' })
     ;({ app, client } = await setupApplication(pocket))
 
     const response = await client
       .post('/v1/sd9fj31d714kgos42e68f9gh')
-      .send({ method: 'eth_blockNumber', params: [], id: 1, jsonrpc: '2.0' })
+      .send({ method: 'eth_chainId', params: [], id: 1, jsonrpc: '2.0' })
       .set('Accept', 'application/json')
       .set('host', 'eth-mainnet-x')
       .expect(200)


### PR DESCRIPTION
As the title implies, there's a possibility of cherry picker receiving `nodes` variable with a value of `0` causing it to fail instead of using altruists. This happens when no nodes passed both checks (only for EVM chains). 

These should be rare cases because if a node can pass the sync check, it (should) mean it has passed the chainID check too. It was happening quite often on blockchain `0024` though. 

It was hard to track because the logs for cherry picker didn't include blockchainID so you don't see them until you look for them. This may or may not solve the inconsistency on `0024`, but this is the only bug I've spotted so far.