### PR TITLE
revert: session log

### DIFF
--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -531,7 +531,7 @@ export class PocketRelayer {
     }
 
     if (nodes.length === 0) {
-      logger.log('warn', `SESSION: ${pocketSession.sessionKey} has exhausted all node relays`, {
+      logger.log('warn', `SESSION: ${sessionKey} has exhausted all node relays`, {
         requestID: requestID,
         relayType: 'APP',
         typeID: application.id,


### PR DESCRIPTION
reverts session log message to not use the `blockchainHash` word