### PR TITLE
Directly send Datadog logs

### DIFF
--- a/.github/workflows/canary-ap-southeast-1.yml
+++ b/.github/workflows/canary-ap-southeast-1.yml
@@ -50,11 +50,13 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/canary-eu-south-1.yml
+++ b/.github/workflows/canary-eu-south-1.yml
@@ -50,11 +50,13 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/canary-eu-west-1.yml
+++ b/.github/workflows/canary-eu-west-1.yml
@@ -50,11 +50,13 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/canary-us-east-2.yml
+++ b/.github/workflows/canary-us-east-2.yml
@@ -50,11 +50,13 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/canary-us-west-2.yml
+++ b/.github/workflows/canary-us-west-2.yml
@@ -50,11 +50,13 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/production-ap-southeast-1.yml
+++ b/.github/workflows/production-ap-southeast-1.yml
@@ -50,12 +50,14 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
           envkey_ALWAYS_REDIRECT_TO_ALTRUISTS: ${{ secrets.ALWAYS_REDIRECT_TO_ALTRUISTS }}
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/production-eu-south-1.yml
+++ b/.github/workflows/production-eu-south-1.yml
@@ -50,12 +50,14 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
           envkey_ALWAYS_REDIRECT_TO_ALTRUISTS: ${{ secrets.ALWAYS_REDIRECT_TO_ALTRUISTS }}
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/production-eu-west-1.yml
+++ b/.github/workflows/production-eu-west-1.yml
@@ -50,12 +50,14 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
           envkey_ALWAYS_REDIRECT_TO_ALTRUISTS: ${{ secrets.ALWAYS_REDIRECT_TO_ALTRUISTS }}
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/production-us-east-2.yml
+++ b/.github/workflows/production-us-east-2.yml
@@ -50,12 +50,14 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
           envkey_ALWAYS_REDIRECT_TO_ALTRUISTS: ${{ secrets.ALWAYS_REDIRECT_TO_ALTRUISTS }}
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/production-us-west-2.yml
+++ b/.github/workflows/production-us-west-2.yml
@@ -50,12 +50,14 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
           envkey_ALWAYS_REDIRECT_TO_ALTRUISTS: ${{ secrets.ALWAYS_REDIRECT_TO_ALTRUISTS }}
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/.github/workflows/staging-us-west-2.yml
+++ b/.github/workflows/staging-us-west-2.yml
@@ -50,12 +50,14 @@ jobs:
           envkey_INFLUX_ORG: 'pocket'
           envkey_INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           envkey_PSQL_CONNECTION: ${{ secrets.PSQL_CONNECTION }}
-          envkey_LOG_TO_CLOUDWATCH: true
+          envkey_LOG_TO_CLOUDWATCH: false
           envkey_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           envkey_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           envkey_COMMIT_HASH: ${{ github.sha }}
           envkey_ARCHIVAL_CHAINS: '0022,0028,0010,000A,000B,000C'
           envkey_ALWAYS_REDIRECT_TO_ALTRUISTS: ${{ secrets.ALWAYS_REDIRECT_TO_ALTRUISTS }}
+          envKey_LOG_TO_DATADOG: true
+          envKey_DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           file_name: .env
 
       - name: Build, tag, and push image to Amazon ECR

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@pokt-network/pocket-js": "^0.6.17-rc",
         "aws-sdk": "^2.1023.0",
         "axios": "^0.21.1",
+        "datadog-winston": "^1.5.1",
         "dotenv": "^8.2.0",
         "eslint-plugin-import": "^2.23.4",
         "ethers": "^5.4.1",
@@ -445,6 +446,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4567,6 +4579,16 @@
       "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/datadog-winston": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/datadog-winston/-/datadog-winston-1.5.1.tgz",
+      "integrity": "sha512-dkMFYTZp0gdF5ThKKsZUPyHrjUyAsp7ITKaoP3l61DXUqnMRUb3kMlvoI7zB+jEBBTsd/RnO+pDoOcuudo7VJA==",
+      "dependencies": {
+        "@babel/runtime": "^7.4.5",
+        "node-fetch": "^2.6.0",
+        "winston-transport": "^4.3.0"
       }
     },
     "node_modules/dataloader": {
@@ -9086,6 +9108,17 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/node-fetch-h2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
@@ -10954,6 +10987,11 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -12442,6 +12480,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/transform-filter": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/transform-filter/-/transform-filter-0.1.1.tgz",
@@ -12991,6 +13034,20 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
       "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -13737,6 +13794,14 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
       "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==",
       "dev": true
+    },
+    "@babel/runtime": {
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
     },
     "@babel/template": {
       "version": "7.15.4",
@@ -16973,6 +17038,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
       "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+    },
+    "datadog-winston": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/datadog-winston/-/datadog-winston-1.5.1.tgz",
+      "integrity": "sha512-dkMFYTZp0gdF5ThKKsZUPyHrjUyAsp7ITKaoP3l61DXUqnMRUb3kMlvoI7zB+jEBBTsd/RnO+pDoOcuudo7VJA==",
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "node-fetch": "^2.6.0",
+        "winston-transport": "^4.3.0"
+      }
     },
     "dataloader": {
       "version": "1.4.0",
@@ -20471,6 +20546,14 @@
         "tslib": "^2.0.3"
       }
     },
+    "node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-fetch-h2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
@@ -21949,6 +22032,11 @@
       "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
       "dev": true
     },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -23124,6 +23212,11 @@
         }
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "transform-filter": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/transform-filter/-/transform-filter-0.1.1.tgz",
@@ -23587,6 +23680,20 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
       "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@pokt-network/pocket-js": "^0.6.17-rc",
     "aws-sdk": "^2.1023.0",
     "axios": "^0.21.1",
+    "datadog-winston": "^1.5.1",
     "dotenv": "^8.2.0",
     "eslint-plugin-import": "^2.23.4",
     "ethers": "^5.4.1",

--- a/src/observers/environment.observer.ts
+++ b/src/observers/environment.observer.ts
@@ -41,7 +41,6 @@ export class EnvironmentObserver implements LifeCycleObserver {
     // Not required in code, but must be present in .env
     'AWS_ACCESS_KEY_ID',
     'AWS_SECRET_ACCESS_KEY',
-    'AWS_REGION',
   ]
 
   private static requiredEnvVarsOnlyInProd = ['COMMIT_HASH']


### PR DESCRIPTION
Instead of sending the logs to AWS so they can be fordwarded to datadog, this sets the logs to be sent directly to datadog without any hops