### PR TITLE
Feature/sc 63/polish client node stickiness

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -178,14 +178,13 @@ export class V1Controller {
 
       const { stickiness = false, stickinessDuration = DEFAULT_STICKINESS_DURATION } = loadBalancer
 
-      const stickinessData = stickiness
+      const { preferredApplicationID, preferredNodeAddress, rpcID } = stickiness
         ? await this.checkClientStickiness(rawData)
         : {
             preferredApplicationID: '',
             preferredNodeAddress: '',
             rpcID: 0,
           }
-      const { preferredApplicationID, preferredNodeAddress, rpcID } = stickinessData
 
       const application = await this.fetchLoadBalancerApplication(
         loadBalancer.id,
@@ -275,13 +274,9 @@ export class V1Controller {
       if (application?.id) {
         const { stickiness = false, stickinessDuration = DEFAULT_STICKINESS_DURATION } = application
 
-        const stickinessData = stickiness
+        const { preferredNodeAddress, rpcID } = stickiness
           ? await this.checkClientStickiness(rawData)
-          : {
-              preferredNodeAddress: '',
-              rpcID: 0,
-            }
-        const { preferredNodeAddress, rpcID } = stickinessData
+          : { preferredNodeAddress: '', rpcID: 0 }
 
         const sendRelayOptions: SendRelayOptions = {
           rawData,

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -19,7 +19,12 @@ import { loadBlockchain } from '../utils/relayer'
 import { SendRelayOptions } from '../utils/types'
 const logger = require('../services/logger')
 
-const DEFAULT_STICKINESS_DURATION = 300
+const DEFAULT_STICKINESS_DURATION = 300 // Seconds
+const DEFAULT_STICKINESS_PARAMS = {
+  preferredApplicationID: '',
+  preferredNodeAddress: '',
+  rpcID: 0,
+}
 
 export class V1Controller {
   cherryPicker: CherryPicker
@@ -180,11 +185,7 @@ export class V1Controller {
 
       const { preferredApplicationID, preferredNodeAddress, rpcID } = stickiness
         ? await this.checkClientStickiness(rawData)
-        : {
-            preferredApplicationID: '',
-            preferredNodeAddress: '',
-            rpcID: 0,
-          }
+        : DEFAULT_STICKINESS_PARAMS
 
       const application = await this.fetchLoadBalancerApplication(
         loadBalancer.id,
@@ -276,7 +277,7 @@ export class V1Controller {
 
         const { preferredNodeAddress, rpcID } = stickiness
           ? await this.checkClientStickiness(rawData)
-          : { preferredNodeAddress: '', rpcID: 0 }
+          : DEFAULT_STICKINESS_PARAMS
 
         const sendRelayOptions: SendRelayOptions = {
           rawData,

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -19,6 +19,8 @@ import { loadBlockchain } from '../utils/relayer'
 import { SendRelayOptions } from '../utils/types'
 const logger = require('../services/logger')
 
+const DEFAULT_STICKINESS_DURATION = 300
+
 export class V1Controller {
   cherryPicker: CherryPicker
   metricsRecorder: MetricsRecorder
@@ -173,7 +175,16 @@ export class V1Controller {
 
       // Fetch applications contained in this Load Balancer. Verify they exist and choose
       // one randomly for the relay. First check RPC ID to see if this client should be stuck to an app and node.
-      const { preferredApplicationID, preferredNodeAddress, rpcID } = await this.checkClientStickiness(rawData)
+
+      const { stickiness = false, stickinessDuration = DEFAULT_STICKINESS_DURATION } = loadBalancer
+
+      const { preferredApplicationID, preferredNodeAddress, rpcID } = stickiness
+        ? await this.checkClientStickiness(rawData)
+        : {
+            preferredApplicationID: '',
+            preferredNodeAddress: '',
+            rpcID: 0,
+          }
 
       const application = await this.fetchLoadBalancerApplication(
         loadBalancer.id,
@@ -193,6 +204,7 @@ export class V1Controller {
         httpMethod: this.httpMethod,
         application,
         preferredNodeAddress,
+        stickinessDuration,
         requestID: this.requestID,
         requestTimeOut: parseInt(loadBalancer.requestTimeOut),
         overallTimeOut: parseInt(loadBalancer.overallTimeOut),
@@ -258,14 +270,20 @@ export class V1Controller {
 
     try {
       const application = await this.fetchApplication(id, filter)
-      const { preferredNodeAddress, rpcID } = await this.checkClientStickiness(rawData)
 
       if (application?.id) {
+        const { stickiness = false, stickinessDuration = DEFAULT_STICKINESS_DURATION } = application
+
+        const { preferredNodeAddress, rpcID } = stickiness
+          ? await this.checkClientStickiness(rawData)
+          : { preferredNodeAddress: '', rpcID: 0 }
+
         const sendRelayOptions: SendRelayOptions = {
           rawData,
           rpcID,
           application,
           preferredNodeAddress,
+          stickinessDuration,
           relayPath: this.relayPath,
           httpMethod: this.httpMethod,
           requestID: this.requestID,
@@ -312,6 +330,7 @@ export class V1Controller {
       })
 
       const clientStickyKey = `${this.ipAddress}-${blockchainID}-${rpcID}`
+
       const clientStickyAppNodeRaw = await this.redis.get(clientStickyKey)
       const clientStickyAppNode = JSON.parse(clientStickyAppNodeRaw)
 

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -335,7 +335,6 @@ export class V1Controller {
       const clientStickyAppNode = JSON.parse(clientStickyAppNodeRaw)
 
       if (clientStickyAppNode?.applicationID && clientStickyAppNode?.nodeAddress) {
-        logger.log('info', `STICKINESS FOUND ${clientStickyKey} ${JSON.stringify(clientStickyAppNode)}`)
         return {
           preferredApplicationID: clientStickyAppNode.applicationID,
           preferredNodeAddress: clientStickyAppNode.nodeAddress,

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -178,13 +178,14 @@ export class V1Controller {
 
       const { stickiness = false, stickinessDuration = DEFAULT_STICKINESS_DURATION } = loadBalancer
 
-      const { preferredApplicationID, preferredNodeAddress, rpcID } = stickiness
+      const stickinessData = stickiness
         ? await this.checkClientStickiness(rawData)
         : {
             preferredApplicationID: '',
             preferredNodeAddress: '',
             rpcID: 0,
           }
+      const { preferredApplicationID, preferredNodeAddress, rpcID } = stickinessData
 
       const application = await this.fetchLoadBalancerApplication(
         loadBalancer.id,
@@ -274,9 +275,13 @@ export class V1Controller {
       if (application?.id) {
         const { stickiness = false, stickinessDuration = DEFAULT_STICKINESS_DURATION } = application
 
-        const { preferredNodeAddress, rpcID } = stickiness
+        const stickinessData = stickiness
           ? await this.checkClientStickiness(rawData)
-          : { preferredNodeAddress: '', rpcID: 0 }
+          : {
+              preferredNodeAddress: '',
+              rpcID: 0,
+            }
+        const { preferredNodeAddress, rpcID } = stickinessData
 
         const sendRelayOptions: SendRelayOptions = {
           rawData,

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -330,7 +330,6 @@ export class V1Controller {
       })
 
       const clientStickyKey = `${this.ipAddress}-${blockchainID}-${rpcID}`
-
       const clientStickyAppNodeRaw = await this.redis.get(clientStickyKey)
       const clientStickyAppNode = JSON.parse(clientStickyAppNodeRaw)
 

--- a/src/models/applications.model.ts
+++ b/src/models/applications.model.ts
@@ -43,7 +43,19 @@ export class Applications extends Entity {
   @property({
     type: 'object',
   })
-  aat?: object;
+  aat?: object
+
+  @property({
+    type: 'boolean',
+    required: false,
+  })
+  stickiness?: boolean
+
+  @property({
+    type: 'number',
+    required: false,
+  })
+  stickinessDuration?: number;
 
   // Define well-known properties here
 

--- a/src/models/load-balancers.model.ts
+++ b/src/models/load-balancers.model.ts
@@ -30,7 +30,19 @@ export class LoadBalancers extends Entity {
   @property({
     type: 'number',
   })
-  logLimitBlocks?: number;
+  logLimitBlocks?: number
+
+  @property({
+    type: 'boolean',
+    required: false,
+  })
+  stickiness?: boolean
+
+  @property({
+    type: 'number',
+    required: false,
+  })
+  stickinessDuration?: number;
 
   // Define well-known properties here
 

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -25,6 +25,7 @@ interface Log {
   serviceDomain: string
   sessionKey: string
   sessionHash: string
+  sticky: boolean
 }
 
 const environment = process.env.NODE_ENV || 'production'
@@ -57,8 +58,9 @@ const consoleFormat = printf(
     serviceDomain = '',
     sessionKey = '',
     sessionHash = '',
+    sticky = false,
   }: Log) => {
-    return `[${timestampUTC()}] [${level}] [${requestID}] [${relayType}] [${typeID}] [${serviceNode}] [${serviceURL}] [${serviceDomain}] [${sessionKey}] [${sessionHash}] [${error}] [${elapsedTime}] [${blockchainID}] [${origin}] ${message}`
+    return `[${timestampUTC()}] [${level}] [${requestID}] [${relayType}] [${typeID}] [${serviceNode}] [${serviceURL}] [${serviceDomain}] [${sessionKey}] [${sessionHash}] [${error}] [${elapsedTime}] [${blockchainID}] [${origin}] [sticky: ${sticky}] ${message}`
   }
 )
 

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -25,7 +25,7 @@ interface Log {
   serviceDomain: string
   sessionKey: string
   sessionHash: string
-  sticky: boolean
+  sticky: string
 }
 
 const environment = process.env.NODE_ENV || 'production'
@@ -58,7 +58,7 @@ const consoleFormat = printf(
     serviceDomain = '',
     sessionKey = '',
     sessionHash = '',
-    sticky = false,
+    sticky = 'NONE',
   }: Log) => {
     return `[${timestampUTC()}] [${level}] [${requestID}] [${relayType}] [${typeID}] [${serviceNode}] [${serviceURL}] [${serviceDomain}] [${sessionKey}] [${sessionHash}] [${error}] [${elapsedTime}] [${blockchainID}] [${origin}] [sticky: ${sticky}] ${message}`
   }

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -83,7 +83,7 @@ export class MetricsRecorder {
     data: string | undefined
     pocketSession: Session | undefined
     timeout?: number
-    sticky?: boolean
+    sticky?: string
   }): Promise<void> {
     try {
       const { sessionNodes } = pocketSession || {}

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -65,6 +65,7 @@ export class MetricsRecorder {
     data,
     pocketSession,
     timeout,
+    sticky,
   }: {
     requestID: string
     applicationID: string
@@ -82,6 +83,7 @@ export class MetricsRecorder {
     data: string | undefined
     pocketSession: Session | undefined
     timeout?: number
+    sticky?: boolean
   }): Promise<void> {
     try {
       const { sessionNodes } = pocketSession || {}
@@ -121,6 +123,7 @@ export class MetricsRecorder {
           origin,
           blockchainID,
           sessionHash,
+          sticky,
         })
       } else if (result === 500) {
         logger.log('error', 'FAILURE' + fallbackTag + ' RELAYING ' + blockchainID + ' req: ' + data, {
@@ -135,6 +138,7 @@ export class MetricsRecorder {
           origin,
           blockchainID,
           sessionHash,
+          sticky,
         })
       } else if (result === 503) {
         logger.log('error', 'INVALID RESPONSE' + fallbackTag + ' RELAYING ' + blockchainID + ' req: ' + data, {
@@ -149,6 +153,7 @@ export class MetricsRecorder {
           origin,
           blockchainID,
           sessionHash,
+          sticky,
         })
       }
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -126,6 +126,7 @@ export class PocketRelayer {
     httpMethod,
     application,
     preferredNodeAddress,
+    stickinessDuration,
     requestID,
     requestTimeOut,
     overallTimeOut,
@@ -210,6 +211,7 @@ export class PocketRelayer {
             requestID,
             application,
             preferredNodeAddress,
+            stickinessDuration,
             requestTimeOut,
             blockchainID,
             blockchainEnforceResult,
@@ -441,6 +443,7 @@ export class PocketRelayer {
     requestID,
     application,
     preferredNodeAddress,
+    stickinessDuration,
     requestTimeOut,
     blockchainEnforceResult,
     blockchainSyncCheck,
@@ -456,6 +459,7 @@ export class PocketRelayer {
     requestID: string
     application: Applications
     preferredNodeAddress: string | undefined
+    stickinessDuration: number | undefined
     requestTimeOut: number | undefined
     blockchainEnforceResult: string
     blockchainSyncCheck: SyncCheckOptions
@@ -783,7 +787,7 @@ export class PocketRelayer {
             clientStickyKey,
             JSON.stringify({ applicationID: application.id, nodeAddress: node.address }),
             'EX',
-            300
+            stickinessDuration
           )
           const clientStickyAppNodeRaw = await this.redis.get(clientStickyKey)
           const clientStickyAppNode = JSON.parse(clientStickyAppNodeRaw)

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -241,7 +241,7 @@ export class PocketRelayer {
                 origin: this.origin,
                 data,
                 pocketSession: this.pocketSession,
-                sticky: preferredNodeAddress === (await getAddressFromPublicKey(relayResponse.proof.servicerPubKey)),
+                sticky: await PocketRelayer.stickyRelayResult(preferredNodeAddress, relayResponse.proof.servicerPubKey),
               })
               .catch(function log(e) {
                 logger.log('error', 'Error recording metrics: ' + e, {
@@ -295,7 +295,7 @@ export class PocketRelayer {
                 origin: this.origin,
                 data,
                 pocketSession: this.pocketSession,
-                sticky: preferredNodeAddress === (await getAddressFromPublicKey(relayResponse.servicer_node)),
+                sticky: await PocketRelayer.stickyRelayResult(preferredNodeAddress, relayResponse.servicer_node),
               })
               .catch(function log(e) {
                 logger.log('error', 'Error recording metrics: ' + e, {
@@ -832,5 +832,16 @@ export class PocketRelayer {
       pocketConfiguration.validateRelayResponses,
       pocketConfiguration.rejectSelfSignedCertificates
     )
+  }
+
+  static async stickyRelayResult(
+    prefferedNodeAddress: string | undefined,
+    relayNodePublicKey: string
+  ): Promise<string> {
+    if (!prefferedNodeAddress) {
+      return 'NONE'
+    }
+
+    return prefferedNodeAddress === (await getAddressFromPublicKey(relayNodePublicKey)) ? 'SUCCESS' : 'FAILURE'
   }
 }

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -835,13 +835,13 @@ export class PocketRelayer {
   }
 
   static async stickyRelayResult(
-    prefferedNodeAddress: string | undefined,
+    preferredNodeAddress: string | undefined,
     relayNodePublicKey: string
   ): Promise<string> {
-    if (!prefferedNodeAddress) {
+    if (!preferredNodeAddress) {
       return 'NONE'
     }
 
-    return prefferedNodeAddress === (await getAddressFromPublicKey(relayNodePublicKey)) ? 'SUCCESS' : 'FAILURE'
+    return preferredNodeAddress === (await getAddressFromPublicKey(relayNodePublicKey)) ? 'SUCCESS' : 'FAILURE'
   }
 }

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -697,8 +697,6 @@ export class PocketRelayer {
 
     let node: Node
 
-    // console.log('------ NODES ADDRESS:', nodes.map((n) => n.address))
-    // console.log('------ NODES PUBLICK EY:', nodes.map((n) => n.publicKey))
     // Before cherry picking, check to see if preferred node is in the set of good nodes
     const preferredNodeIndex = nodes.findIndex((x) => x.address === preferredNodeAddress)
 
@@ -706,7 +704,6 @@ export class PocketRelayer {
       node = nodes[preferredNodeIndex]
     } else {
       node = await this.cherryPicker.cherryPickNode(application, nodes, blockchainID, requestID)
-      console.log('SELECTED', node.address, node.publicKey)
     }
 
     if (this.checkDebug) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -16,6 +16,7 @@ export type SendRelayOptions = {
   application: Applications
   rpcID?: number
   preferredNodeAddress?: string
+  stickinessDuration?: number
   httpMethod: HTTPMethod
   overallTimeOut?: number
   rawData: object | string

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -182,7 +182,6 @@ describe('V1 controller (acceptance)', () => {
 
     await loadBalancersRepository.createAll(LOAD_BALANCERS)
     await blockchainsRepository.createAll(BLOCKCHAINS)
-
     await applicationsRepository.createAll(APPLICATIONS)
   })
 
@@ -545,7 +544,6 @@ describe('V1 controller (acceptance)', () => {
 
     const relayRequest = (id) => `{"method":"eth_chainId","id":${id},"jsonrpc":"2.0"}`
     const relayResponseData = (id) => `{"id":${id},"jsonrpc":"2.0","result":"0x64"}`
-
     const mockPocket = new PocketMock()
 
     // Reset default values

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -586,7 +586,7 @@ describe('V1 controller (acceptance)', () => {
           'info',
           sinon.match.any,
           sinon.match((log: object) => {
-            return log['sticky'] === true
+            return log['sticky'] === 'SUCCESS'
           })
         )
           ? ++successStickyResponses

--- a/tests/mocks/pocketjs.ts
+++ b/tests/mocks/pocketjs.ts
@@ -187,7 +187,9 @@ export class PocketMock {
           It.IsAny()
         )
       )
-      .callback(({ args: [data] }) => Promise.resolve(this._sendRelay(data)))
+      .callback(({ args: [data, blockchain, pocketAAT, configuration, headers, method, path, node] }) =>
+        Promise.resolve(this._sendRelay(data, node))
+      )
 
     return repoMock.object()
   }
@@ -237,7 +239,9 @@ export class PocketMock {
    * @param data relay request payload
    * @returns response payload of request
    */
-  _sendRelay(data: string): RelayResponse | RpcError {
+  _sendRelay(data: string, node?: Node): RelayResponse | RpcError {
+    const nodePublicKey = node ? node.publicKey : '142e2b65610a798b0e4e3f45927ae0b986a71852039c28a625dcf11d2fc48637'
+
     let relayResponse
 
     const _relayResponse = this._getRelayResponse(data)
@@ -258,7 +262,7 @@ export class PocketMock {
         new RelayProofResponse(
           BigInt(17386131212264644),
           BigInt(32889),
-          '142e2b65610a798b0e4e3f45927ae0b986a71852039c28a625dcf11d2fc48637',
+          nodePublicKey,
           '0027',
           poktAAT,
           'c57e5076153450855e7018ab5b8de37034f04d4884f33020f339fc634228951ff1ecb69f39ab31bc6544f869f6ce10dd4cbc186fceb496d02b443a9420d09b03',
@@ -270,7 +274,7 @@ export class PocketMock {
           new RelayProof(
             BigInt(17386131212264644),
             BigInt(32889),
-            '142e2b65610a798b0e4e3f45927ae0b986a71852039c28a625dcf11d2fc48637',
+            nodePublicKey,
             '0027',
             poktAAT,
             'c57e5076153450855e7018ab5b8de37034f04d4884f33020f339fc634228951ff1ecb69f39ab31bc6544f869f6ce10dd4cbc186fceb496d02b443a9420d09b03',

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -1208,7 +1208,7 @@ describe('Pocket relayer service (unit)', () => {
             'info',
             sinon.match.any,
             sinon.match((log: object) => {
-              return log['sticky'] === true
+              return log['sticky'] === 'SUCCESS'
             })
           )
             ? ++successStickyResponses


### PR DESCRIPTION
* Adds lb/app config for stickiness
* Modified pocket mock to return node public key
* Remove sticky logs in favor of single boolean on metrics recorder which is `true` if the call was a sticky success
* Add unit and acceptance test