### PR TITLE
feat: next sticky requests are set right away

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -13,3 +13,15 @@ export function hashBlockchainNodes(blockchainID: string, nodes: Node[] = []): s
     )
     .digest('hex')}`
 }
+
+export function getNextRPCID(rpcID: number, rawData: string | object): number {
+  const parsedRawData = Object.keys(rawData).length > 0 ? JSON.parse(rawData.toString()) : JSON.stringify(rawData)
+  let nextRPCID = rpcID + 1
+
+  // If this was a stacked RPC call with multiple calls in an array, increment the RPC ID accordingly
+  if (parsedRawData instanceof Array) {
+    nextRPCID = rpcID + parsedRawData.length
+  }
+
+  return nextRPCID
+}


### PR DESCRIPTION
now, instead of setting the next sticky requests once the relay succeeds, they're set right away once stickiness is set and removed if the relay fails, think about it like innocent until proven guilty.

< joke>blame [Ole Roemer](https://en.wikipedia.org/wiki/Ole_R%C3%B8mer) for creating the speed of light and making me do this< /joke>