### PR TITLE
Stickiness: Set rpcID or full sticky

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -14,7 +14,6 @@ import { CherryPicker } from '../services/cherry-picker'
 import { MetricsRecorder } from '../services/metrics-recorder'
 import { PocketRelayer } from '../services/pocket-relayer'
 import { SyncChecker } from '../services/sync-checker'
-import { getNextRPCID } from '../utils/helpers'
 import { parseRPCID } from '../utils/parsing'
 import { loadBlockchain } from '../utils/relayer'
 import { SendRelayOptions } from '../utils/types'
@@ -182,8 +181,8 @@ export class V1Controller {
       // Fetch applications contained in this Load Balancer. Verify they exist and choose
       // one randomly for the relay. First check RPC ID to see if this client should be stuck to an app and node.
 
-      const { stickiness = false, stickinessDuration = DEFAULT_STICKINESS_DURATION } = loadBalancer
-      const stickyKeyPrefix = stickiness ? loadBalancer?.id : ''
+      const { stickiness = false, stickinessDuration = DEFAULT_STICKINESS_DURATION, useRPCID = true } = loadBalancer
+      const stickyKeyPrefix = stickiness && !useRPCID ? loadBalancer?.id : ''
 
       const { preferredApplicationID, preferredNodeAddress, rpcID } = stickiness
         ? await this.checkClientStickiness(rawData, stickyKeyPrefix)

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -209,6 +209,7 @@ export class V1Controller {
         overallTimeOut: parseInt(loadBalancer.overallTimeOut),
         relayRetries: parseInt(loadBalancer.relayRetries),
         stickinessOptions: {
+          stickiness,
           preferredNodeAddress,
           duration: stickinessDuration,
           keyPrefix: stickyKeyPrefix,
@@ -291,6 +292,7 @@ export class V1Controller {
           httpMethod: this.httpMethod,
           requestID: this.requestID,
           stickinessOptions: {
+            stickiness,
             preferredNodeAddress,
             duration: stickinessDuration,
             keyPrefix: stickyKeyPrefix,

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -179,8 +179,11 @@ export class V1Controller {
       }
 
       // Fetch applications contained in this Load Balancer. Verify they exist and choose
-      // one randomly for the relay. First check RPC ID to see if this client should be stuck to an app and node.
-
+      // one randomly for the relay.
+      // For sticking sessions (sessions which must be relied using the same node for data consistency)
+      // There's two ways to handle them: rpcID or prefix (full sticky), on rpcID the stickiness works
+      // with increasing rpcID relays to maintain consistency and with prefix all relays from a load
+      // balancer go to the same app/node regardless the data.
       const { stickiness = false, stickinessDuration = DEFAULT_STICKINESS_DURATION, useRPCID = true } = loadBalancer
       const stickyKeyPrefix = stickiness && !useRPCID ? loadBalancer?.id : ''
 

--- a/src/models/load-balancers.model.ts
+++ b/src/models/load-balancers.model.ts
@@ -42,7 +42,14 @@ export class LoadBalancers extends Entity {
     type: 'number',
     required: false,
   })
-  stickinessDuration?: number;
+  stickinessDuration?: number
+
+  @property({
+    type: 'number',
+    required: false,
+    default: true,
+  })
+  useRPCID?: boolean;
 
   // Define well-known properties here
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -832,10 +832,17 @@ export class PocketRelayer {
       return
     }
 
-    // If no key prefix is given, set based on rpcID
+    // If no key prefix is given, set based on rpcID.
+    // Prefix is needed in case the rpcID is not used due to the way the key works.
+    // If the key only had ip and blockcChainID, then could happen the unlikely case
+    // where when connected to two different apps that both have stickiness on,
+    // one will overwrite the other with its session node and the other will have an
+    // invalid node to send relays to resulting in a cascade of failures=
     if (keyPrefix) {
       const clientStickyKey = `${keyPrefix}-${this.ipAddress}-${blockchainID}`
 
+      // Check if key is already set to rotate the selected node when the
+      // sticky duration ends
       const nextRequest = await this.redis.get(clientStickyKey)
 
       if (nextRequest) {

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -846,9 +846,8 @@ export class PocketRelayer {
     } else {
       const nextRPCID = getNextRPCID(rpcID, data)
       const clientStickyKey = `${nextRPCID}-${this.ipAddress}-${blockchainID}`
-      const nextRequest = await this.redis.get(clientStickyKey)
 
-      if (!nextRequest && rpcID > 0) {
+      if (rpcID > 0) {
         await this.redis.set(clientStickyKey, JSON.stringify({ applicationID, nodeAddress }), 'EX', duration)
 
         // Some rpcID requests skips one number when sending them consecutively

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -822,13 +822,13 @@ export class PocketRelayer {
   }
 
   async setStickinessKey(
-    { duration, keyPrefix, rpcID }: StickinessOptions,
+    { stickiness, duration, keyPrefix, rpcID }: StickinessOptions,
     blockchainID: string,
     applicationID: string,
     nodeAddress: string,
     data: string
   ): Promise<void> {
-    if (!keyPrefix && !rpcID) {
+    if (!stickiness || (!keyPrefix && !rpcID)) {
       return
     }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -14,9 +14,7 @@ export type BlockchainDetails = {
 
 export type SendRelayOptions = {
   application: Applications
-  rpcID?: number
-  preferredNodeAddress?: string
-  stickinessDuration?: number
+  stickinessOptions: StickinessOptions
   httpMethod: HTTPMethod
   overallTimeOut?: number
   rawData: object | string
@@ -25,4 +23,11 @@ export type SendRelayOptions = {
   requestTimeOut?: number
   relayRetries?: number
   logLimitBlocks?: number
+}
+
+export type StickinessOptions = {
+  preferredNodeAddress: string
+  duration: number
+  keyPrefix?: string
+  rpcID?: number
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,6 +26,7 @@ export type SendRelayOptions = {
 }
 
 export type StickinessOptions = {
+  stickiness: boolean
   preferredNodeAddress: string
   duration: number
   keyPrefix?: string

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -143,6 +143,17 @@ const LOAD_BALANCERS = [
     stickiness: true,
     stickinessDuration: 300,
   },
+  {
+    id: 'df9gjsjg43db9fsajfjg93fk',
+    user: 'test@test.com',
+    name: 'test load balancer',
+    requestTimeout: 5000,
+    applicationIDs: APPLICATIONS.map((app) => app.id),
+    logLimitBlocks: 25000,
+    stickiness: true,
+    stickinessDuration: 300,
+    useRPCID: false,
+  },
 ]
 
 describe('V1 controller (acceptance)', () => {
@@ -539,7 +550,7 @@ describe('V1 controller (acceptance)', () => {
     expect(response.body.message).to.be.equal('Invalid domain')
   })
 
-  it('Perfoms sticky requests on LBs that support it', async () => {
+  it('Perfoms sticky requests on LBs that support it using rpcID', async () => {
     const logSpy = sinon.spy(logger, 'log')
 
     const relayRequest = (id) => `{"method":"eth_chainId","id":${id},"jsonrpc":"2.0"}`
@@ -568,6 +579,60 @@ describe('V1 controller (acceptance)', () => {
       const response = await client
         .post('/v1/lb/gt4a1s9rfrebaf8g31bsdc05')
         .send({ method: 'eth_chainId', id: i, jsonrpc: '2.0' })
+        .set('Accept', 'application/json')
+        .set('host', 'eth-mainnet-x')
+        .expect(200)
+
+      expect(response.headers).to.containDeep({ 'content-type': 'application/json' })
+      expect(response.body).to.have.properties('id', 'jsonrpc', 'result')
+      expect(parseInt(response.body.result, 16)).to.be.aboveOrEqual(0)
+    }
+
+    // Counts the number of times the sticky relay succeeded
+    let successStickyResponses = 0
+
+    logSpy.getCalls().forEach(
+      (call) =>
+        (successStickyResponses = call.calledWith(
+          'info',
+          sinon.match.any,
+          sinon.match((log: object) => {
+            return log['sticky'] === 'SUCCESS'
+          })
+        )
+          ? ++successStickyResponses
+          : successStickyResponses)
+    )
+
+    // First request does  not count as sticky
+    expect(successStickyResponses).to.be.equal(4)
+  })
+
+  it('Perfoms sticky requests on LBs that support it using prefix', async () => {
+    const logSpy = sinon.spy(logger, 'log')
+
+    const relayRequest = '{"method":"eth_chainId","id":0,"jsonrpc":"2.0"}'
+    const mockPocket = new PocketMock()
+
+    // Reset default values
+    mockPocket.relayResponse = {}
+
+    // Sync/Chain check
+    mockPocket.relayResponse['{"method":"eth_chainId","id":1,"jsonrpc":"2.0"}'] =
+      '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
+    mockPocket.relayResponse['{"method":"eth_blockNumber","id":1,"jsonrpc":"2.0"}'] =
+      '{"id":1,"jsonrpc":"2.0","result":"0x1083d57"}'
+
+    mockPocket.relayResponse[relayRequest] = '{"id":0,"jsonrpc":"2.0","result":"0x64"}'
+
+    const pocketClass = mockPocket.class()
+
+    ;({ app, client } = await setupApplication(pocketClass))
+
+    for (let i = 1; i <= 5; i++) {
+      const response = await client
+        .post('/v1/lb/df9gjsjg43db9fsajfjg93fk')
+        .send({ method: 'eth_chainId', id: 1, jsonrpc: '2.0' })
         .set('Accept', 'application/json')
         .set('host', 'eth-mainnet-x')
         .expect(200)

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -495,6 +495,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -548,6 +549,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -598,6 +600,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -647,6 +650,7 @@ describe('Pocket relayer service (unit)', () => {
         overallTimeOut: 1,
         relayRetries: 1,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -693,6 +697,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -755,6 +760,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -780,6 +786,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -845,6 +852,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -870,6 +878,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -926,6 +935,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -978,6 +988,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -1029,6 +1040,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -1082,6 +1094,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -1133,6 +1146,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -1187,6 +1201,7 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: undefined,
         overallTimeOut: undefined,
         stickinessOptions: {
+          stickiness: false,
           duration: 0,
           preferredNodeAddress: '',
         },
@@ -1247,6 +1262,7 @@ describe('Pocket relayer service (unit)', () => {
           httpMethod: HTTPMethod.POST,
           application: APPLICATION as unknown as Applications,
           stickinessOptions: {
+            stickiness: true,
             preferredNodeAddress,
             rpcID: i,
             duration: 300,
@@ -1327,6 +1343,7 @@ describe('Pocket relayer service (unit)', () => {
           httpMethod: HTTPMethod.POST,
           application: APPLICATION as unknown as Applications,
           stickinessOptions: {
+            stickiness: true,
             preferredNodeAddress,
             rpcID: 0,
             duration: 300,
@@ -1408,6 +1425,7 @@ describe('Pocket relayer service (unit)', () => {
             requestTimeOut: undefined,
             overallTimeOut: undefined,
             stickinessOptions: {
+              stickiness: false,
               duration: 0,
               preferredNodeAddress: '',
             },
@@ -1467,6 +1485,7 @@ describe('Pocket relayer service (unit)', () => {
             requestTimeOut: undefined,
             overallTimeOut: undefined,
             stickinessOptions: {
+              stickiness: false,
               duration: 0,
               preferredNodeAddress: '',
             },
@@ -1525,6 +1544,7 @@ describe('Pocket relayer service (unit)', () => {
             requestTimeOut: undefined,
             overallTimeOut: undefined,
             stickinessOptions: {
+              stickiness: false,
               duration: 0,
               preferredNodeAddress: '',
             },
@@ -1598,6 +1618,7 @@ describe('Pocket relayer service (unit)', () => {
           requestTimeOut: undefined,
           overallTimeOut: undefined,
           stickinessOptions: {
+            stickiness: false,
             duration: 0,
             preferredNodeAddress: '',
           },
@@ -1623,6 +1644,7 @@ describe('Pocket relayer service (unit)', () => {
           requestTimeOut: undefined,
           overallTimeOut: undefined,
           stickinessOptions: {
+            stickiness: false,
             duration: 0,
             preferredNodeAddress: '',
           },
@@ -1648,6 +1670,7 @@ describe('Pocket relayer service (unit)', () => {
           requestTimeOut: undefined,
           overallTimeOut: undefined,
           stickinessOptions: {
+            stickiness: false,
             duration: 0,
             preferredNodeAddress: '',
           },
@@ -1672,6 +1695,7 @@ describe('Pocket relayer service (unit)', () => {
           requestTimeOut: undefined,
           overallTimeOut: undefined,
           stickinessOptions: {
+            stickiness: false,
             duration: 0,
             preferredNodeAddress: '',
           },
@@ -1704,6 +1728,7 @@ describe('Pocket relayer service (unit)', () => {
           requestTimeOut: undefined,
           overallTimeOut: undefined,
           stickinessOptions: {
+            stickiness: false,
             duration: 0,
             preferredNodeAddress: '',
           },
@@ -1741,6 +1766,7 @@ describe('Pocket relayer service (unit)', () => {
           requestTimeOut: undefined,
           overallTimeOut: undefined,
           stickinessOptions: {
+            stickiness: false,
             duration: 0,
             preferredNodeAddress: '',
           },
@@ -1803,6 +1829,7 @@ describe('Pocket relayer service (unit)', () => {
           requestTimeOut: undefined,
           overallTimeOut: undefined,
           stickinessOptions: {
+            stickiness: false,
             duration: 0,
             preferredNodeAddress: '',
           },
@@ -1835,6 +1862,7 @@ describe('Pocket relayer service (unit)', () => {
           requestTimeOut: undefined,
           overallTimeOut: undefined,
           stickinessOptions: {
+            stickiness: false,
             duration: 0,
             preferredNodeAddress: '',
           },

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -494,6 +494,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
       const expected = JSON.parse(mock.relayResponse[rawData] as string)
@@ -543,6 +547,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
       const expected = JSON.parse(mock.relayResponse[rawData] as string)
@@ -589,6 +597,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
       const expected = mock.relayResponse[rawData]
@@ -634,6 +646,10 @@ describe('Pocket relayer service (unit)', () => {
         requestTimeOut: 0,
         overallTimeOut: 1,
         relayRetries: 1,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
       })
 
       expect(relayResponse).to.be.instanceOf(HttpErrors.GatewayTimeout)
@@ -676,6 +692,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
 
@@ -734,6 +754,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
 
@@ -755,6 +779,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
 
@@ -816,6 +844,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
 
@@ -837,6 +869,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
 
@@ -889,6 +925,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
 
@@ -937,6 +977,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
 
@@ -984,6 +1028,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
 
@@ -1033,6 +1081,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })) as Error
 
@@ -1080,6 +1132,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })) as Error
 
@@ -1130,6 +1186,10 @@ describe('Pocket relayer service (unit)', () => {
         requestID: '1234',
         requestTimeOut: undefined,
         overallTimeOut: undefined,
+        stickinessOptions: {
+          duration: 0,
+          preferredNodeAddress: '',
+        },
         relayRetries: 0,
       })
 
@@ -1186,9 +1246,11 @@ describe('Pocket relayer service (unit)', () => {
           relayPath: '',
           httpMethod: HTTPMethod.POST,
           application: APPLICATION as unknown as Applications,
-          preferredNodeAddress,
-          rpcID: i,
-          stickinessDuration: 300,
+          stickinessOptions: {
+            preferredNodeAddress,
+            rpcID: i,
+            duration: 300,
+          },
           requestID: '1234',
           requestTimeOut: undefined,
           overallTimeOut: undefined,
@@ -1264,6 +1326,10 @@ describe('Pocket relayer service (unit)', () => {
             requestID: '1234',
             requestTimeOut: undefined,
             overallTimeOut: undefined,
+            stickinessOptions: {
+              duration: 0,
+              preferredNodeAddress: '',
+            },
             relayRetries: 0,
           })
         } catch (error) {
@@ -1319,6 +1385,10 @@ describe('Pocket relayer service (unit)', () => {
             requestID: '1234',
             requestTimeOut: undefined,
             overallTimeOut: undefined,
+            stickinessOptions: {
+              duration: 0,
+              preferredNodeAddress: '',
+            },
             relayRetries: 0,
           })
         } catch (error) {
@@ -1373,6 +1443,10 @@ describe('Pocket relayer service (unit)', () => {
             requestID: '1234',
             requestTimeOut: undefined,
             overallTimeOut: undefined,
+            stickinessOptions: {
+              duration: 0,
+              preferredNodeAddress: '',
+            },
             relayRetries: 0,
           })
         } catch (error) {
@@ -1442,6 +1516,10 @@ describe('Pocket relayer service (unit)', () => {
           requestID: '1234',
           requestTimeOut: undefined,
           overallTimeOut: undefined,
+          stickinessOptions: {
+            duration: 0,
+            preferredNodeAddress: '',
+          },
           relayRetries: 0,
         })
 
@@ -1463,6 +1541,10 @@ describe('Pocket relayer service (unit)', () => {
           requestID: '1234',
           requestTimeOut: undefined,
           overallTimeOut: undefined,
+          stickinessOptions: {
+            duration: 0,
+            preferredNodeAddress: '',
+          },
           relayRetries: 0,
         })
 
@@ -1484,6 +1566,10 @@ describe('Pocket relayer service (unit)', () => {
           requestID: '1234',
           requestTimeOut: undefined,
           overallTimeOut: undefined,
+          stickinessOptions: {
+            duration: 0,
+            preferredNodeAddress: '',
+          },
 
           relayRetries: 0,
         })
@@ -1504,6 +1590,10 @@ describe('Pocket relayer service (unit)', () => {
           requestID: '1234',
           requestTimeOut: undefined,
           overallTimeOut: undefined,
+          stickinessOptions: {
+            duration: 0,
+            preferredNodeAddress: '',
+          },
           relayRetries: 0,
         })
 
@@ -1532,6 +1622,10 @@ describe('Pocket relayer service (unit)', () => {
           requestID: '1234',
           requestTimeOut: undefined,
           overallTimeOut: undefined,
+          stickinessOptions: {
+            duration: 0,
+            preferredNodeAddress: '',
+          },
           relayRetries: 0,
         })) as Error
 
@@ -1565,6 +1659,10 @@ describe('Pocket relayer service (unit)', () => {
           requestID: '1234',
           requestTimeOut: undefined,
           overallTimeOut: undefined,
+          stickinessOptions: {
+            duration: 0,
+            preferredNodeAddress: '',
+          },
           relayRetries: 0,
         })
 
@@ -1623,6 +1721,10 @@ describe('Pocket relayer service (unit)', () => {
           requestID: '1234',
           requestTimeOut: undefined,
           overallTimeOut: undefined,
+          stickinessOptions: {
+            duration: 0,
+            preferredNodeAddress: '',
+          },
           relayRetries: 0,
         })
 
@@ -1651,6 +1753,10 @@ describe('Pocket relayer service (unit)', () => {
           requestID: '1234',
           requestTimeOut: undefined,
           overallTimeOut: undefined,
+          stickinessOptions: {
+            duration: 0,
+            preferredNodeAddress: '',
+          },
           relayRetries: 0,
         })) as Error
 


### PR DESCRIPTION
Add option to either set stickiness based on rpcID (relays with increment ids will be stickied with the same node) or full sticky (all relays go through the same node), default is rpcID