### PR TITLE
Stickiness relay  limit

### DIFF
--- a/src/models/applications.model.ts
+++ b/src/models/applications.model.ts
@@ -1,4 +1,5 @@
 import { Entity, model, property } from '@loopback/repository'
+import { StickinessOptions } from './load-balancers.model'
 
 @model({ settings: { strict: false } })
 export class Applications extends Entity {
@@ -55,7 +56,14 @@ export class Applications extends Entity {
     type: 'number',
     required: false,
   })
-  stickinessDuration?: number;
+  stickinessDuration?: number
+
+  @property({
+    type: 'object',
+    required: false,
+    defautl: {},
+  })
+  stickinessOptions?: StickinessOptions;
 
   // Define well-known properties here
 

--- a/src/models/load-balancers.model.ts
+++ b/src/models/load-balancers.model.ts
@@ -1,5 +1,33 @@
 import { Entity, model, property } from '@loopback/repository'
 
+@model()
+export class StickinessOptions {
+  @property({
+    type: 'boolean',
+    required: true,
+  })
+  stickiness: boolean
+
+  @property({
+    type: 'number',
+    required: true,
+  })
+  duration: number
+
+  @property({
+    type: 'boolean',
+    required: false,
+    default: true,
+  })
+  useRPCID?: boolean
+
+  @property({
+    type: 'number',
+    required: false,
+  })
+  relaysLimit?: number
+}
+
 @model({ settings: { strict: false } })
 export class LoadBalancers extends Entity {
   @property({
@@ -49,7 +77,14 @@ export class LoadBalancers extends Entity {
     required: false,
     default: true,
   })
-  useRPCID?: boolean;
+  useRPCID?: boolean
+
+  @property({
+    type: 'object',
+    required: false,
+    defautl: {},
+  })
+  stickinessOptions?: StickinessOptions;
 
   // Define well-known properties here
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -837,7 +837,7 @@ export class PocketRelayer {
     // If the key only had ip and blockcChainID, then could happen the unlikely case
     // where when connected to two different apps that both have stickiness on,
     // one will overwrite the other with its session node and the other will have an
-    // invalid node to send relays to resulting in a cascade of failures=
+    // invalid node to send relays to resulting in a cascade of failures.
     if (keyPrefix) {
       const clientStickyKey = `${keyPrefix}-${this.ipAddress}-${blockchainID}`
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -29,6 +29,7 @@ export type StickinessOptions = {
   stickiness: boolean
   preferredNodeAddress: string
   duration: number
+  relaysLimit?: number
   keyPrefix?: string
   rpcID?: number
 }

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -140,8 +140,12 @@ const LOAD_BALANCERS = [
     requestTimeout: 5000,
     applicationIDs: APPLICATIONS.map((app) => app.id),
     logLimitBlocks: 25000,
-    stickiness: true,
-    stickinessDuration: 300,
+    stickinessOptions: {
+      stickiness: true,
+      duration: 300,
+      useRPCID: true,
+      relaysLimit: 1e6,
+    },
   },
   {
     id: 'df9gjsjg43db9fsajfjg93fk',
@@ -150,9 +154,12 @@ const LOAD_BALANCERS = [
     requestTimeout: 5000,
     applicationIDs: APPLICATIONS.map((app) => app.id),
     logLimitBlocks: 25000,
-    stickiness: true,
-    stickinessDuration: 300,
-    useRPCID: false,
+    stickinessOptions: {
+      stickiness: true,
+      duration: 300,
+      useRPCID: false,
+      relaysLimit: 1e6,
+    },
   },
 ]
 


### PR DESCRIPTION
Adds stickiness eventual relay limit using redis counters, this is to stop apps which could send a huge amount of relays from the same address, also made a db file structure change as the stickiness options were growing