### PR TITLE
Remove stickiness on exhausted nodes; small refactor

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -29,6 +29,7 @@ const DEFAULT_STICKINESS_PARAMS = {
   duration: 30, // seconds
   useRPCID: true,
   relaysLimit: 0,
+  whitelistOrigins: [],
 }
 
 export class V1Controller {
@@ -189,7 +190,7 @@ export class V1Controller {
       // There's two ways to handle them: rpcID or prefix (full sticky), on rpcID the stickiness works
       // with increasing rpcID relays to maintain consistency and with prefix all relays from a load
       // balancer go to the same app/node regardless the data.
-      const { stickiness, duration, useRPCID, relaysLimit } =
+      const { stickiness, duration, useRPCID, relaysLimit, whitelistOrigins } =
         loadBalancer?.stickinessOptions || DEFAULT_STICKINESS_PARAMS
       const stickyKeyPrefix = stickiness && !useRPCID ? loadBalancer?.id : ''
 
@@ -224,6 +225,7 @@ export class V1Controller {
           keyPrefix: stickyKeyPrefix,
           rpcID,
           relaysLimit,
+          whitelistOrigins,
         },
       }
 
@@ -288,7 +290,7 @@ export class V1Controller {
       const application = await this.fetchApplication(id, filter)
 
       if (application?.id) {
-        const { stickiness, duration, useRPCID, relaysLimit } =
+        const { stickiness, duration, useRPCID, relaysLimit, whitelistOrigins } =
           application?.stickinessOptions || DEFAULT_STICKINESS_PARAMS
         const stickyKeyPrefix = stickiness && !useRPCID ? application?.id : ''
 
@@ -309,6 +311,7 @@ export class V1Controller {
             keyPrefix: stickyKeyPrefix,
             rpcID,
             relaysLimit,
+            whitelistOrigins,
           },
         }
 

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -29,7 +29,7 @@ const DEFAULT_STICKINESS_PARAMS = {
   duration: 30, // seconds
   useRPCID: true,
   relaysLimit: 0,
-  whitelistOrigins: [],
+  stickyOrigins: [],
 }
 
 export class V1Controller {
@@ -190,7 +190,7 @@ export class V1Controller {
       // There's two ways to handle them: rpcID or prefix (full sticky), on rpcID the stickiness works
       // with increasing rpcID relays to maintain consistency and with prefix all relays from a load
       // balancer go to the same app/node regardless the data.
-      const { stickiness, duration, useRPCID, relaysLimit, whitelistOrigins } =
+      const { stickiness, duration, useRPCID, relaysLimit, stickyOrigins } =
         loadBalancer?.stickinessOptions || DEFAULT_STICKINESS_PARAMS
       const stickyKeyPrefix = stickiness && !useRPCID ? loadBalancer?.id : ''
 
@@ -225,7 +225,7 @@ export class V1Controller {
           keyPrefix: stickyKeyPrefix,
           rpcID,
           relaysLimit,
-          whitelistOrigins,
+          stickyOrigins,
         },
       }
 
@@ -290,7 +290,7 @@ export class V1Controller {
       const application = await this.fetchApplication(id, filter)
 
       if (application?.id) {
-        const { stickiness, duration, useRPCID, relaysLimit, whitelistOrigins } =
+        const { stickiness, duration, useRPCID, relaysLimit, stickyOrigins } =
           application?.stickinessOptions || DEFAULT_STICKINESS_PARAMS
         const stickyKeyPrefix = stickiness && !useRPCID ? application?.id : ''
 
@@ -311,7 +311,7 @@ export class V1Controller {
             keyPrefix: stickyKeyPrefix,
             rpcID,
             relaysLimit,
-            whitelistOrigins,
+            stickyOrigins,
           },
         }
 

--- a/src/models/load-balancers.model.ts
+++ b/src/models/load-balancers.model.ts
@@ -26,6 +26,13 @@ export class StickinessOptions {
     required: false,
   })
   relaysLimit?: number
+
+  @property({
+    type: 'array',
+    itemType: 'string',
+    required: false,
+  })
+  whitelistOrigins?: string[]
 }
 
 @model({ settings: { strict: false } })

--- a/src/models/load-balancers.model.ts
+++ b/src/models/load-balancers.model.ts
@@ -32,7 +32,7 @@ export class StickinessOptions {
     itemType: 'string',
     required: false,
   })
-  whitelistOrigins?: string[]
+  stickyOrigins?: string[]
 }
 
 @model({ settings: { strict: false } })

--- a/src/services/node-sticker.ts
+++ b/src/services/node-sticker.ts
@@ -17,7 +17,7 @@ export class NodeSticker {
   keyPrefix?: string
   rpcID?: number
   relaysLimit?: number
-  whitelistOrigins?: string[]
+  stickyOrigins?: string[]
 
   redis: Redis
   blockchainID: string
@@ -31,7 +31,7 @@ export class NodeSticker {
   clientLimitKey: string
 
   constructor(
-    { stickiness, duration, keyPrefix, rpcID, relaysLimit, preferredNodeAddress, whitelistOrigins }: StickinessOptions,
+    { stickiness, duration, keyPrefix, rpcID, relaysLimit, preferredNodeAddress, stickyOrigins }: StickinessOptions,
     blockchainID: string,
     ipAddress: string,
     redis: Redis,
@@ -45,7 +45,7 @@ export class NodeSticker {
     this.keyPrefix = keyPrefix
     this.rpcID = rpcID
     this.relaysLimit = relaysLimit
-    this.whitelistOrigins = whitelistOrigins
+    this.stickyOrigins = stickyOrigins
 
     this.blockchainID = blockchainID
     this.ipAddress = ipAddress
@@ -131,7 +131,7 @@ export class NodeSticker {
       return
     }
 
-    if (!checkWhitelist(this.whitelistOrigins, origin, 'substring')) {
+    if (!checkWhitelist(this.stickyOrigins, origin, 'substring')) {
       return
     }
 

--- a/src/services/node-sticker.ts
+++ b/src/services/node-sticker.ts
@@ -17,10 +17,12 @@ export class NodeSticker {
   relaysLimit?: number
   preferredNodeAddress: string
 
+  redis: Redis
   blockchainID: string
   ipAddress: string
-  redis: Redis
   data?: string | object
+  requestID?: string
+  typeID?: string
 
   clientStickyKey: string
   clientErrorKey: string
@@ -31,7 +33,9 @@ export class NodeSticker {
     blockchainID: string,
     ipAddress: string,
     redis: Redis,
-    data?: string | object
+    data?: string | object,
+    requestID?: string,
+    typeID?: string
   ) {
     this.stickiness = stickiness
     this.duration = duration
@@ -44,6 +48,8 @@ export class NodeSticker {
     this.ipAddress = ipAddress
     this.redis = redis
     this.data = data
+    this.requestID = requestID
+    this.typeID = typeID
 
     // If no key prefix is given, set based on rpcID.
     // Prefix is needed in case the rpcID is not used due to the way the key works.
@@ -86,13 +92,7 @@ export class NodeSticker {
     return preferredNodeAddress === (await getAddressFromPublicKey(relayNodePublicKey)) ? 'SUCCESS' : 'FAILURE'
   }
 
-  async getStickyNode(
-    nodes: Node[],
-    exhaustedNodes: string[],
-    requestID?: string,
-    blockchainID?: string,
-    applicationID?: string
-  ): Promise<Node | undefined> {
+  async getStickyNode(nodes: Node[], exhaustedNodes: string[]): Promise<Node | undefined> {
     const preferredNodeIndex = nodes.findIndex(({ address }) => address === this.preferredNodeAddress)
 
     if (preferredNodeIndex < 0) {
@@ -103,7 +103,7 @@ export class NodeSticker {
     if (
       exhaustedNodes.some(async (publicKey) => (await getAddressFromPublicKey(publicKey)) === this.preferredNodeAddress)
     ) {
-      await this.remove(requestID, blockchainID, applicationID)
+      await this.remove('exhausted node')
       return undefined
     }
 
@@ -111,19 +111,14 @@ export class NodeSticker {
     const errorCount = await this.getErrorCount()
 
     if (errorCount > 5) {
-      await this.remove(requestID, blockchainID, applicationID)
+      await this.remove('error limit exceeded')
       return undefined
     }
 
     return nodes[preferredNodeIndex]
   }
 
-  async setStickinessKey(
-    blockchainID: string,
-    applicationID: string,
-    nodeAddress: string,
-    relayLimiter = true
-  ): Promise<void> {
+  async setStickinessKey(applicationID: string, nodeAddress: string, relayLimiter = true): Promise<void> {
     if (!this.stickiness || (!this.keyPrefix && !this.rpcID)) {
       return
     }
@@ -143,7 +138,7 @@ export class NodeSticker {
         const nextRPCID = NodeSticker.getNextRPCID(this.rpcID, this.data)
 
         // Some rpcID requests skips one number when sending them consecutively
-        const nextClientStickyKey = `${this.ipAddress}-${blockchainID}-${nextRPCID + 1}`
+        const nextClientStickyKey = `${this.ipAddress}-${this.blockchainID}-${nextRPCID + 1}`
 
         await this.redis.set(nextClientStickyKey, JSON.stringify({ applicationID, nodeAddress }), 'EX', this.duration)
       }
@@ -158,24 +153,22 @@ export class NodeSticker {
   // await is not used here as the value does not need to be exact, a small
   // overflow is allowed.
   async checkRelaysLimit(): Promise<void> {
-    const limitKey = `${this.clientStickyKey}-limit`
+    const relaysDone = Number.parseInt((await this.redis.get(this.clientLimitKey)) || '0')
 
-    const relaysDone = Number.parseInt((await this.redis.get(limitKey)) || '0')
-
-    this.redis.incr(limitKey)
+    this.redis.incr(this.clientLimitKey)
 
     if (!relaysDone) {
-      this.redis.expire(limitKey, this.duration)
+      this.redis.expire(this.clientLimitKey, this.duration)
     } else if (relaysDone >= this.relaysLimit) {
-      await this.remove()
+      await this.remove('relays limit exceeded')
     }
   }
 
-  async remove(requestID?: string, blockchainID?: string, typeID?: string): Promise<void> {
-    logger.log('info', 'sticky node forcefully removed', {
-      requestID,
-      typeID,
-      blockchainID,
+  async remove(reason?: string): Promise<void> {
+    logger.log('info', `sticky node forcefully removed${reason ? `: ${reason}` : ''}`, {
+      requestID: this.requestID,
+      typeID: this.typeID,
+      blockchainID: this.blockchainID,
       serviceNode: this.preferredNodeAddress,
     })
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -705,7 +705,7 @@ export class PocketRelayer {
 
     let node: Node
 
-    if (nodeSticker.stickiness) {
+    if (nodeSticker.preferredNodeAddress) {
       node = await nodeSticker.getStickyNode(nodes, exhaustedNodes, requestID, blockchainID, application.id)
     }
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -782,7 +782,7 @@ export class PocketRelayer {
         // then this result is invalid
         return new RelayError(relayResponse.payload, 503, relayResponse.proof.servicerPubKey)
       } else {
-        await nodeSticker.setStickinessKey(application.id, node.address)
+        await nodeSticker.setStickinessKey(application.id, node.address, this.origin)
 
         // Success
         return relayResponse

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -152,7 +152,15 @@ export class PocketRelayer {
     )
 
     const { preferredNodeAddress } = stickinessOptions
-    const nodeSticker = new NodeSticker(stickinessOptions, blockchainID, this.ipAddress, this.redis, rawData)
+    const nodeSticker = new NodeSticker(
+      stickinessOptions,
+      blockchainID,
+      this.ipAddress,
+      this.redis,
+      rawData,
+      requestID,
+      application.id
+    )
 
     const overallStart = process.hrtime()
 
@@ -285,7 +293,7 @@ export class PocketRelayer {
               const errorCount = await nodeSticker.increaseErrorCount()
 
               if (errorCount > 5) {
-                await nodeSticker.remove(requestID, blockchainID, application.id)
+                await nodeSticker.remove('error limit exceeded')
               }
             }
 
@@ -706,7 +714,7 @@ export class PocketRelayer {
     let node: Node
 
     if (nodeSticker.preferredNodeAddress) {
-      node = await nodeSticker.getStickyNode(nodes, exhaustedNodes, requestID, blockchainID, application.id)
+      node = await nodeSticker.getStickyNode(nodes, exhaustedNodes)
     }
 
     if (!node) {
@@ -774,7 +782,7 @@ export class PocketRelayer {
         // then this result is invalid
         return new RelayError(relayResponse.payload, 503, relayResponse.proof.servicerPubKey)
       } else {
-        await nodeSticker.setStickinessKey(blockchainID, application.id, node.address)
+        await nodeSticker.setStickinessKey(application.id, node.address)
 
         // Success
         return relayResponse

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -32,5 +32,5 @@ export type StickinessOptions = {
   relaysLimit?: number
   keyPrefix?: string
   rpcID?: number
-  whitelistOrigins?: string[]
+  stickyOrigins?: string[]
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -32,4 +32,5 @@ export type StickinessOptions = {
   relaysLimit?: number
   keyPrefix?: string
   rpcID?: number
+  whitelistOrigins?: string[]
 }

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -173,7 +173,7 @@ const LOAD_BALANCERS = [
       duration: 300,
       useRPCID: false,
       relaysLimit: 1e6,
-      whitelistOrigins: ['localhost'],
+      stickyOrigins: ['localhost'],
     },
   },
 ]

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -136,7 +136,7 @@ const LOAD_BALANCERS = [
   {
     id: 'gt4a1s9rfrebaf8g31bsdc05',
     user: 'test@test.com',
-    name: 'test load balancer',
+    name: 'test load balancer sticky rpc',
     requestTimeout: 5000,
     applicationIDs: APPLICATIONS.map((app) => app.id),
     logLimitBlocks: 25000,
@@ -150,7 +150,7 @@ const LOAD_BALANCERS = [
   {
     id: 'df9gjsjg43db9fsajfjg93fk',
     user: 'test@test.com',
-    name: 'test load balancer',
+    name: 'test load balancer sticky prefix',
     requestTimeout: 5000,
     applicationIDs: APPLICATIONS.map((app) => app.id),
     logLimitBlocks: 25000,
@@ -159,6 +159,21 @@ const LOAD_BALANCERS = [
       duration: 300,
       useRPCID: false,
       relaysLimit: 1e6,
+    },
+  },
+  {
+    id: 'd8ejd7834ht9d9sj345gfsoaao',
+    user: 'test@test.com',
+    name: 'test load balancer sticky prefix with whitelist',
+    requestTimeout: 5000,
+    applicationIDs: APPLICATIONS.map((app) => app.id),
+    logLimitBlocks: 25000,
+    stickinessOptions: {
+      stickiness: true,
+      duration: 300,
+      useRPCID: false,
+      relaysLimit: 1e6,
+      whitelistOrigins: ['localhost'],
     },
   },
 ]
@@ -666,6 +681,113 @@ describe('V1 controller (acceptance)', () => {
     )
 
     // First request does  not count as sticky
+    expect(successStickyResponses).to.be.equal(4)
+  })
+
+  it('Fails sticky requests due to not being on whitelist', async () => {
+    const logSpy = sinon.spy(logger, 'log')
+
+    const relayRequest = '{"method":"eth_chainId","id":0,"jsonrpc":"2.0"}'
+    const mockPocket = new PocketMock()
+
+    // Reset default values
+    mockPocket.relayResponse = {}
+
+    // Sync/Chain check
+    mockPocket.relayResponse['{"method":"eth_chainId","id":1,"jsonrpc":"2.0"}'] =
+      '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
+    mockPocket.relayResponse['{"method":"eth_blockNumber","id":1,"jsonrpc":"2.0"}'] =
+      '{"id":1,"jsonrpc":"2.0","result":"0x1083d57"}'
+
+    mockPocket.relayResponse[relayRequest] = '{"id":0,"jsonrpc":"2.0","result":"0x64"}'
+
+    const pocketClass = mockPocket.class()
+
+    ;({ app, client } = await setupApplication(pocketClass))
+
+    for (let i = 1; i <= 5; i++) {
+      const response = await client
+        .post('/v1/lb/d8ejd7834ht9d9sj345gfsoaao')
+        .send({ method: 'eth_chainId', id: 1, jsonrpc: '2.0' })
+        .set('Accept', 'application/json')
+        .set('host', 'eth-mainnet-x')
+        .expect(200)
+
+      expect(response.headers).to.containDeep({ 'content-type': 'application/json' })
+      expect(response.body).to.have.properties('id', 'jsonrpc', 'result')
+      expect(parseInt(response.body.result, 16)).to.be.aboveOrEqual(0)
+    }
+
+    // Counts the number of times the sticky relay succeeded
+    let successStickyResponses = 0
+
+    logSpy.getCalls().forEach(
+      (call) =>
+        (successStickyResponses = call.calledWith(
+          'info',
+          sinon.match.any,
+          sinon.match((log: object) => {
+            return log['sticky'] === 'SUCCESS'
+          })
+        )
+          ? ++successStickyResponses
+          : successStickyResponses)
+    )
+
+    expect(successStickyResponses).to.be.equal(0)
+  })
+
+  it('Pass sticky requests due to being on whitelist', async () => {
+    const logSpy = sinon.spy(logger, 'log')
+
+    const relayRequest = '{"method":"eth_chainId","id":0,"jsonrpc":"2.0"}'
+    const mockPocket = new PocketMock()
+
+    // Reset default values
+    mockPocket.relayResponse = {}
+
+    // Sync/Chain check
+    mockPocket.relayResponse['{"method":"eth_chainId","id":1,"jsonrpc":"2.0"}'] =
+      '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
+    mockPocket.relayResponse['{"method":"eth_blockNumber","id":1,"jsonrpc":"2.0"}'] =
+      '{"id":1,"jsonrpc":"2.0","result":"0x1083d57"}'
+
+    mockPocket.relayResponse[relayRequest] = '{"id":0,"jsonrpc":"2.0","result":"0x64"}'
+
+    const pocketClass = mockPocket.class()
+
+    ;({ app, client } = await setupApplication(pocketClass))
+
+    for (let i = 1; i <= 5; i++) {
+      const response = await client
+        .post('/v1/lb/d8ejd7834ht9d9sj345gfsoaao')
+        .send({ method: 'eth_chainId', id: 1, jsonrpc: '2.0' })
+        .set('Accept', 'application/json')
+        .set('host', 'eth-mainnet-x')
+        .set('origin', 'localhost')
+        .expect(200)
+
+      expect(response.headers).to.containDeep({ 'content-type': 'application/json' })
+      expect(response.body).to.have.properties('id', 'jsonrpc', 'result')
+      expect(parseInt(response.body.result, 16)).to.be.aboveOrEqual(0)
+    }
+
+    // Counts the number of times the sticky relay succeeded
+    let successStickyResponses = 0
+
+    logSpy.getCalls().forEach(
+      (call) =>
+        (successStickyResponses = call.calledWith(
+          'info',
+          sinon.match.any,
+          sinon.match((log: object) => {
+            return log['sticky'] === 'SUCCESS'
+          })
+        )
+          ? ++successStickyResponses
+          : successStickyResponses)
+    )
+
     expect(successStickyResponses).to.be.equal(4)
   })
 })


### PR DESCRIPTION
as the title says, remove stickiness on exhausted nodes,  small refactor on getting sticky node with much cleaner code and overall moved log variables to constructor to minimize repeated arguments on some methods