### PR TITLE
cherry picker refinements

### DIFF
--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -301,18 +301,18 @@ export class CherryPicker {
     // The app/node with the highest success rate and the lowest average latency will
     // be 10 times more likely to be selected than a node that has had failures.
     let weightFactor = 10
-    let fastestNodeLatency = 0
+    let previousNodeLatency = 0
     let latencyDifference = 0
 
     // This multiplier is tested to produce a curve that adequately punishes slow nodes
-    const weightMultiplier = 8
+    const weightMultiplier = 14
 
     for (const sortedLog of sortedLogs) {
       // Set the benchmark from the fastest node
-      if (!fastestNodeLatency) {
-        fastestNodeLatency = sortedLog.averageSuccessLatency
+      if (!previousNodeLatency) {
+        previousNodeLatency = sortedLog.averageSuccessLatency
       } else {
-        latencyDifference = sortedLog.averageSuccessLatency - fastestNodeLatency
+        latencyDifference = sortedLog.averageSuccessLatency - previousNodeLatency
       }
 
       // The amount you subtract here from the weight factor should be variable based on how
@@ -320,9 +320,10 @@ export class CherryPicker {
       // Previously this value was hardcoded 2 in the first bucket
       if (latencyDifference) {
         weightFactor = weightFactor - Math.round(latencyDifference * weightMultiplier)
-      }
-      if (weightFactor <= 0) {
-        weightFactor = 1
+
+        if (weightFactor <= 0) {
+          weightFactor = 1
+        }
       }
 
       // Brand new sessions include all nodes in this group so we avoid putting failures here

--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -305,7 +305,7 @@ export class CherryPicker {
     let latencyDifference = 0
 
     // This multiplier is tested to produce a curve that adequately punishes slow nodes
-    const weightMultiplier = 14
+    const weightMultiplier = 15
 
     for (const sortedLog of sortedLogs) {
       // Set the benchmark from the fastest node

--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -301,23 +301,45 @@ export class CherryPicker {
     // The app/node with the highest success rate and the lowest average latency will
     // be 10 times more likely to be selected than a node that has had failures.
     let weightFactor = 10
+    let fastestNodeLatency = 0
+    let latencyDifference = 0
+
+    // This multiplier is tested to produce a curve that adequately punishes slow nodes
+    const weightMultiplier = 8
 
     for (const sortedLog of sortedLogs) {
+      // Set the benchmark from the fastest node
+      if (!fastestNodeLatency) {
+        fastestNodeLatency = sortedLog.averageSuccessLatency
+      } else {
+        latencyDifference = sortedLog.averageSuccessLatency - fastestNodeLatency
+      }
+
+      // The amount you subtract here from the weight factor should be variable based on how
+      // far off this node's average elapsedTime is from the fastest node.
+      // Previously this value was hardcoded 2 in the first bucket
+      if (latencyDifference) {
+        weightFactor = weightFactor - Math.round(latencyDifference * weightMultiplier)
+      }
+      if (weightFactor <= 0) {
+        weightFactor = 1
+      }
+
       // Brand new sessions include all nodes in this group so we avoid putting failures here
-      if (sortedLog.successRate > 0.98 && !sortedLog.failure) {
-        // For untested apps/nodes and those > 98% success rates, weight their selection
+      if (sortedLog.successRate > 0.95 && !sortedLog.failure) {
+        // For untested apps/nodes and those > 95% success rates, weight their selection
         for (let x = 1; x <= weightFactor; x++) {
           rankedItems.push(sortedLog.id)
         }
-        weightFactor = weightFactor - 2
-      } else if (sortedLog.successRate > 0.95 && !sortedLog.failure) {
+      } else if (sortedLog.successRate > 0.9 && !sortedLog.failure) {
         // For all apps/nodes with reasonable success rate, weight their selection less
-        for (let x = 1; x <= weightFactor; x++) {
-          rankedItems.push(sortedLog.id)
-        }
-        weightFactor = weightFactor - 3
+        weightFactor = weightFactor - 2
         if (weightFactor <= 0) {
           weightFactor = 1
+        }
+
+        for (let x = 1; x <= weightFactor; x++) {
+          rankedItems.push(sortedLog.id)
         }
       } else if (sortedLog.successRate > 0) {
         // For all apps/nodes with limited success rate, do not weight


### PR DESCRIPTION
Currently the cherry picker is a harsh punishment to nodes that are just slightly slower than the fastest. This causes uneven distribution of relays and node-session exhaustion.

In the current code, the weight factor that you subtract for each subsequent ranked node is hardcoded.

This PR changes that hardcoded value to a dynamic value based on how much slower the node is compared to the previous node.

In the current model, let's assume the nodes have an average elapsed latency of: 

```
node 1  0.25ms
node 2  0.31ms
node 3  0.42ms
node 4  0.45ms
node 5  0.7ms
```

Assuming these nodes all have a similar success/error rate, they will be weighted in buckets like this:

```
node1 10
node2 8
node3 6
node4 4
node5 2
```

Where the fastest node is almost 2x more likely to be selected than the 3rd fastest. This remains constant even if those two speeds are very similar. With the new formula, the distribution is:

```
node1 10
node2 9
node3 8
node4 8
node5 4
```

Which I believe better reflects the distribution of average elapsed times.
