### PR TITLE
removing middle success rate bucket, reducing failure mark TTL

### DIFF
--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -331,20 +331,10 @@ export class CherryPicker {
         for (let x = 1; x <= weightFactor; x++) {
           rankedItems.push(sortedLog.id)
         }
-      } else if (sortedLog.successRate > 0.5 && !sortedLog.failure) {
-        // For all apps/nodes with reasonable success rate, weight their selection less
-        weightFactor = weightFactor - 2
-        if (weightFactor <= 0) {
-          weightFactor = 1
-        }
-
-        for (let x = 1; x <= weightFactor; x++) {
-          rankedItems.push(sortedLog.id)
-        }
-      } else if (sortedLog.successRate > 0) {
+      } else if (sortedLog.successRate > 0 && !sortedLog.failure) {
         // For all apps/nodes with limited success rate, do not weight
         rankedItems.push(sortedLog.id)
-      } else if (sortedLog.successRate === 0) {
+      } else {
         // If an app/node has a 0% success rate and < max failures, keep them in rotation
         if (sortedLog.attempts < maxFailuresPerPeriod) {
           rankedItems.push(sortedLog.id)
@@ -356,7 +346,7 @@ export class CherryPicker {
           // Once a node has performed well enough in a session, check to see if it is marked
           // If so, erase the scarlet letter
           if (!sortedLog.failure) {
-            await this.redis.set(blockchain + '-' + sortedLog.id + '-failure', 'true', 'EX', 3600)
+            await this.redis.set(blockchain + '-' + sortedLog.id + '-failure', 'true', 'EX', 300)
           }
         }
       }


### PR DESCRIPTION
The middle success rate bucket was overcomplicating things and also mis-adjusting the weight factor with the new simplified picker. Picker is now easy to read.

Failure mark TTL was still set to an hour, now set to 5 minutes.