### PR TITLE
Dynamically set  next n rpc ids  

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -31,6 +31,7 @@ const DEFAULT_STICKINESS_PARAMS = {
   useRPCID: true,
   relaysLimit: 0,
   stickyOrigins: [],
+  rpcIDThreshold: 2,
 }
 
 export class V1Controller {
@@ -191,7 +192,7 @@ export class V1Controller {
       // There's two ways to handle them: rpcID or prefix (full sticky), on rpcID the stickiness works
       // with increasing rpcID relays to maintain consistency and with prefix all relays from a load
       // balancer go to the same app/node regardless the data.
-      const { stickiness, duration, useRPCID, relaysLimit, stickyOrigins } =
+      const { stickiness, duration, useRPCID, relaysLimit, stickyOrigins, rpcIDThreshold } =
         loadBalancer?.stickinessOptions || DEFAULT_STICKINESS_PARAMS
       const stickyKeyPrefix = stickiness && !useRPCID ? loadBalancer?.id : ''
 
@@ -227,6 +228,7 @@ export class V1Controller {
           rpcID,
           relaysLimit,
           stickyOrigins,
+          rpcIDThreshold,
         },
       }
 

--- a/src/models/load-balancers.model.ts
+++ b/src/models/load-balancers.model.ts
@@ -33,6 +33,12 @@ export class StickinessOptions {
     required: false,
   })
   stickyOrigins?: string[]
+
+  @property({
+    type: 'number',
+    required: false,
+  })
+  rpcIDThreshold?: number
 }
 
 @model({ settings: { strict: false } })

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -33,4 +33,5 @@ export type StickinessOptions = {
   keyPrefix?: string
   rpcID?: number
   stickyOrigins?: string[]
+  rpcIDThreshold?: number
 }

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -145,6 +145,7 @@ const LOAD_BALANCERS = [
       duration: 300,
       useRPCID: true,
       relaysLimit: 1e6,
+      rpcIDThreshold: 2,
     },
   },
   {
@@ -572,7 +573,8 @@ describe('V1 controller (acceptance)', () => {
     expect(response.body.message).to.be.equal('Invalid domain')
   })
 
-  it('Perfoms sticky requests on LBs that support it using rpcID', async () => {
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  it.only('Perfoms sticky requests on LBs that support it using rpcID', async () => {
     const logSpy = sinon.spy(logger, 'log')
 
     const relayRequest = (id) => `{"method":"eth_chainId","id":${id},"jsonrpc":"2.0"}`


### PR DESCRIPTION
Adds the ability to dynamically set through the DB how many next rpc ids are going to be set for an app which supports it. Default set to 2 