### PR TITLE
fix: return same rpcID from req

### DIFF
--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -20,6 +20,11 @@ export function parseMethod(parsedRawData: Record<string, any>): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseRawData(rawData: string | object): Record<string, any> {
+  return Object.keys(rawData).length > 0 ? JSON.parse(rawData.toString()) : JSON.stringify(rawData)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseRPCID(parsedRawData: Record<string, any>): number {
   // RPC ID for client-node stickiness
   let rpcID = 0


### PR DESCRIPTION
Return the same rpcID that came with the request object to comply with JSON-RPC standards.