### PR TITLE
ref: error parsing & handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you ever get an error from the API, it will be in JSON-RPC format. This is ou
 | -32063 | Please use an explicit block number instead of 'latest' | eth_getLogs Limit Error | non-standard |
 | -32064 | You cannot query logs for more than X amount of blocks | eth_getLogs Limit Error | non-standard |
 | -32065 | Node returned an invalid response | The node serving your request returned an invalid response | non-standard |
-| -32066 | Your request body is not proper JSON | We couldn't parse your request body | non-standard |
+| -32066 | The request body is not proper JSON | Request bould couldn't be parsed | non-standard |
 
 ## Support & Contact
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If you ever get an error from the API, it will be in JSON-RPC format. This is ou
 | -32063 | Please use an explicit block number instead of 'latest' | eth_getLogs Limit Error | non-standard |
 | -32064 | You cannot query logs for more than X amount of blocks | eth_getLogs Limit Error | non-standard |
 | -32065 | Node returned an invalid response | The node serving your request returned an invalid response | non-standard |
+| -32066 | Your request body is not proper JSON | We couldn't parse your request body | non-standard |
 
 ## Support & Contact
 

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -369,7 +369,7 @@ export class V1Controller {
       }
 
       if (e instanceof SyntaxError && e.message.includes('JSON')) {
-        return jsonrpc.error(reqRPCID, new JsonRpcError('Your request body is not proper JSON.', -32066))
+        return jsonrpc.error(reqRPCID, new JsonRpcError('The request body is not proper JSON.', -32066))
       }
 
       logger.log('error', 'INTERNAL ERROR: ' + e, {

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -267,7 +267,7 @@ export class V1Controller {
         origin: this.origin,
       })
 
-      return jsonrpc.error(reqRPCID, new JsonRpcError(e.message, -32050))
+      return jsonrpc.error(reqRPCID, new JsonRpcError('Relay attempts exhausted', -32050))
     }
   }
 
@@ -304,8 +304,7 @@ export class V1Controller {
     @param.filter(Applications, { exclude: 'where' })
     filter?: FilterExcludingWhere<Applications>
   ): Promise<string | ErrorObject> {
-    const parsedRawData = parseRawData(rawData)
-    const reqRPCID = parseRPCID(parsedRawData)
+    let reqRPCID = 1
 
     // Take the relay path from the end of the endpoint URL
     if (id.match(/[0-9a-zA-Z]{24}~/g)) {
@@ -314,6 +313,10 @@ export class V1Controller {
     }
 
     try {
+      const parsedRawData = parseRawData(rawData)
+
+      reqRPCID = parseRPCID(parsedRawData)
+
       const application = await this.fetchApplication(id, filter)
 
       if (!application?.id) {
@@ -356,7 +359,7 @@ export class V1Controller {
       if (e instanceof ErrorObject) {
         logger.log('error', e.error.message, {
           requestID: this.requestID,
-          relayType: 'LB',
+          relayType: 'APP',
           typeID: id,
           serviceNode: '',
           origin: this.origin,
@@ -365,15 +368,19 @@ export class V1Controller {
         return e
       }
 
-      logger.log('error', e.message, {
+      if (e instanceof SyntaxError && e.message.includes('JSON')) {
+        return jsonrpc.error(reqRPCID, new JsonRpcError('Your request body is not proper JSON.', -32066))
+      }
+
+      logger.log('error', 'INTERNAL ERROR: ' + e, {
         requestID: this.requestID,
-        relayType: 'LB',
+        relayType: 'APP',
         typeID: id,
         serviceNode: '',
         origin: this.origin,
       })
 
-      return jsonrpc.error(reqRPCID, new JsonRpcError(e.message, -32050))
+      return jsonrpc.error(reqRPCID, new JsonRpcError('Relay attempts exhausted', -32050))
     }
   }
 

--- a/src/services/limiter.ts
+++ b/src/services/limiter.ts
@@ -11,6 +11,7 @@ export async function enforceEVMLimits(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parsedRawData: Record<string, any>,
   blockchainID: string,
+  requestID: string,
   logLimitBlocks: number,
   altruists: JSONObject
 ): Promise<void | ErrorObject> {
@@ -67,7 +68,10 @@ export async function enforceEVMLimits(
           fromBlock = latestBlock
         }
       } catch (e) {
-        logger.log('error', `Failed trying to reach altruist (${altruistUrl}) to fetch block number.`)
+        logger.log('error', `Failed trying to reach altruist (${altruistUrl}) to fetch block number.`, {
+          blockchainID,
+          requestID,
+        })
         return jsonrpc.error(
           rpcID,
           new jsonrpc.JsonRpcError('Try again with a explicit block number.', -32062)

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -240,7 +240,7 @@ export class PocketRelayer {
           })
 
           if (!(relayResponse instanceof Error)) {
-            // Even if we relay is successful, we could get an invalid response from servide node.
+            // Even if the relay is successful, we could get an invalid response from servide node.
             // We attempt to parse the service node response using jsonrpc-lite lib.
             const parsedRelayResponse = jsonrpc.parse(relayResponse.payload as string) as IParsedObject
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -240,8 +240,12 @@ export class PocketRelayer {
           })
 
           if (!(relayResponse instanceof Error)) {
+            // Even if we relay is successful, we could get an invalid response from servide node.
+            // We attempt to parse the service node response using jsonrpc-lite lib.
             const parsedRelayResponse = jsonrpc.parse(relayResponse.payload as string) as IParsedObject
 
+            // If the parsing goes wrong, we get a response with 'invalid' type and the following message.
+            // We could get 'invalid' and not a parse error, hence we check both.
             if (parsedRelayResponse.type === 'invalid' && parsedRelayResponse.payload.message === 'Parse error') {
               throw new ErrorObject(
                 rpcID,

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -362,7 +362,7 @@ export class PocketRelayer {
         throw e
       }
 
-      // Any other error (f.g parsing errors) that should not be propagated as response
+      // Any other error (e.g parsing errors) that should not be propagated as response
       logger.log('error', 'INTERNAL ERROR: ' + e, {
         requestID,
         relayType: 'APP',

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -182,12 +182,12 @@ export class PocketRelayer {
     }
 
     const data = JSON.stringify(parsedRawData)
-    const limitation = await this.enforceLimits(parsedRawData, blockchainID, logLimitBlocks)
+    const limitation = await this.enforceLimits(parsedRawData, blockchainID, requestID, logLimitBlocks)
 
     if (limitation instanceof ErrorObject) {
       logger.log('error', `LIMITATION ERROR ${blockchainID} req: ${data}`, {
         blockchainID,
-        requestID: requestID,
+        requestID,
         relayType: 'APP',
         error: `${parsedRawData.method} method limitations exceeded.`,
         typeID: application.id,
@@ -358,7 +358,8 @@ export class PocketRelayer {
         throw e
       }
 
-      logger.log('error', 'ERROR relaying through node: ' + e, {
+      // Any other error (f.g parsing errors) that should not be propagated as response
+      logger.log('error', 'INTERNAL ERROR: ' + e, {
         requestID,
         relayType: 'APP',
         typeID: application.id,
@@ -836,12 +837,13 @@ export class PocketRelayer {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     parsedRawData: Record<string, any>,
     blockchainID: string,
+    requestID: string,
     logLimitBlocks: number
   ): Promise<void | ErrorObject> {
     let limiterResponse: Promise<void | ErrorObject>
 
     if (blockchainID === '0021') {
-      limiterResponse = enforceEVMLimits(parsedRawData, blockchainID, logLimitBlocks, this.altruists)
+      limiterResponse = enforceEVMLimits(parsedRawData, blockchainID, requestID, logLimitBlocks, this.altruists)
     }
 
     return limiterResponse

--- a/src/utils/enforcements.ts
+++ b/src/utils/enforcements.ts
@@ -1,6 +1,6 @@
 import { Decryptor } from 'strong-cryptor'
 import { Applications } from '../models'
-import { isEVMError, fetchEVMErrorCode, fetchEVMErrorMessage } from './evm'
+import { isEVMError } from './evm'
 
 export function checkEnforcementJSON(test: string): boolean {
   if (!test || test.length === 0) {
@@ -76,14 +76,4 @@ export function isUserError(payload: string): boolean {
   const evmException: boolean = isEVMError(payload)
 
   return evmException
-}
-
-export function fetchUserErrorCode(payload: string): string {
-  // TODO: Non-evm errors
-  return fetchEVMErrorCode(payload)
-}
-
-export function fetchUserErrorMessage(payload: string): string {
-  // TODO: Non-evm errors
-  return fetchEVMErrorMessage(payload)
 }

--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -1,33 +1,17 @@
+import { parseJSONRPCError } from './parsing'
+
 export const EVM_ERROR_CODES = [
   // JSON RPC Standard errors
   '-32',
-  // Custom error codes
-  '1',
-  '2',
-  '3',
 ]
 
 // EVM clients rely on JsonRpc standard, so we check for those errors.
 export function isEVMError(response: string): boolean {
-  const errorCode = fetchEVMErrorCode(response)
+  try {
+    const { code } = parseJSONRPCError(response)
 
-  if (errorCode === 'undefined') {
+    return EVM_ERROR_CODES.some((error) => String(code).includes(error))
+  } catch {
     return false
   }
-
-  return EVM_ERROR_CODES.some((error) => errorCode.includes(error))
-}
-
-export function fetchEVMErrorCode(response: string): string {
-  const parsedResponse = JSON.parse(response)
-  const errorCode = String(parsedResponse.error?.code)
-
-  return errorCode
-}
-
-export function fetchEVMErrorMessage(response: string): string {
-  const parsedResponse = JSON.parse(response)
-  const errorMessage = String(parsedResponse.error?.message)
-
-  return errorMessage
 }

--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -1,3 +1,5 @@
+import jsonrpc, { IParsedObjectError, JsonRpcError } from 'jsonrpc-lite'
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseMethod(parsedRawData: Record<string, any>): string {
   // Method recording for metrics
@@ -40,4 +42,19 @@ export function parseRPCID(parsedRawData: Record<string, any>): number {
     rpcID = parsedRawData.id
   }
   return rpcID
+}
+
+export function parseJSONRPCError(response: string): JsonRpcError {
+  const parsedResponse = jsonrpc.parse(response) as IParsedObjectError
+  const isJSONRpcError = isJSONRPCError(parsedResponse)
+
+  if (isJSONRpcError) {
+    return parsedResponse.payload.error
+  }
+
+  return { code: 0, message: '' }
+}
+
+export function isJSONRPCError(object: unknown): object is IParsedObjectError {
+  return Object.prototype.hasOwnProperty.call(object, 'type') || Object.prototype.hasOwnProperty.call(object, 'payload')
 }

--- a/tests/unit/node-checker.unit.ts
+++ b/tests/unit/node-checker.unit.ts
@@ -243,7 +243,6 @@ describe('Node checker (unit)', () => {
 
     expect(successArchivalCheck.success).to.be.true()
 
-    console.log('LLEGAMO AQUI')
     const successArchivalCheckArray = await nodeChecker.performArchivalCheck(
       DEFAULT_NODES[0],
       ARCHIVALCHECK_PAYLOAD.bodyArray,

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -593,23 +593,26 @@ describe('Pocket relayer service (unit)', () => {
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
       })
 
-      const relayResponse = await poktRelayer.sendRelay({
-        rawData,
-        relayPath: '',
-        httpMethod: HTTPMethod.POST,
-        application: APPLICATION as unknown as Applications,
-        requestID: '1234',
-        requestTimeOut: undefined,
-        overallTimeOut: undefined,
-        stickinessOptions: {
-          stickiness: false,
-          duration: 0,
-          preferredNodeAddress: '',
-        },
-        relayRetries: 0,
-      })
-
-      expect(relayResponse).to.be.instanceOf(ErrorObject)
+      try {
+        await poktRelayer.sendRelay({
+          rawData,
+          relayPath: '',
+          httpMethod: HTTPMethod.POST,
+          application: APPLICATION as unknown as Applications,
+          requestID: '1234',
+          requestTimeOut: undefined,
+          overallTimeOut: undefined,
+          stickinessOptions: {
+            stickiness: false,
+            duration: 0,
+            preferredNodeAddress: '',
+          },
+          relayRetries: 0,
+        })
+      } catch (error) {
+        expect(error).to.be.instanceOf(ErrorObject)
+        expect(error.error.message).to.be.equal('Service Node returned an invalid response')
+      }
     })
 
     it('throws an error when provided timeout is exceeded', async () => {


### PR DESCRIPTION
This PR includes a refactor on error parsing & an additional feature that doesn't allow invalid responses (non JSON-RPC) to be relayed to clients/users.

UPDATE: also added some facets when logging 'failed reaching altruist'  eth_logs limit error.