### PR TITLE
fix: separate redis del multi-key operation

### DIFF
--- a/src/services/node-sticker.ts
+++ b/src/services/node-sticker.ts
@@ -207,7 +207,9 @@ export class NodeSticker {
       serviceNode: this.preferredNodeAddress,
     })
 
-    await this.redis.del(this.clientStickyKey, this.clientErrorKey, this.clientLimitKey)
+    await this.redis.del(this.clientStickyKey)
+    await this.redis.del(this.clientErrorKey)
+    await this.redis.del(this.clientLimitKey)
   }
 
   async increaseErrorCount(): Promise<number> {


### PR DESCRIPTION
Given that we are now using a Redis Cluster, we can no longer use multi-key operations without taking in consideration slots. 

The error:
```
CROSSSLOT Keys in request don't hash to the same slot
```

This PR separates multi-key operation into individual 1-key operations.