### PR TITLE
[DO NOT MERGE] feat: nicer message on GET relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If you ever get an error from the API, it will be in JSON-RPC format. This is ou
 | -32064 | You cannot query logs for more than X amount of blocks | eth_getLogs Limit Error | non-standard |
 | -32065 | Node returned an invalid response | The node serving your request returned an invalid response | non-standard |
 | -32066 | The request body is not proper JSON | The request body couldn't be parsed | non-standard |
+| -32067 | GET requests are not supported. Use POST instead | Attempt to send a relay through a GET request | non-standard |
 
 ## Support & Contact
 

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -1,10 +1,9 @@
-import AWS from 'aws-sdk'
 import { Redis } from 'ioredis'
 import jsonrpc, { ErrorObject, JsonRpcError } from 'jsonrpc-lite'
 import { Pool as PGPool } from 'pg'
 import { inject } from '@loopback/context'
 import { FilterExcludingWhere, repository } from '@loopback/repository'
-import { param, post, requestBody } from '@loopback/rest'
+import { get, param, post, requestBody } from '@loopback/rest'
 import { Configuration, HTTPMethod, Pocket } from '@pokt-network/pocket-js'
 import { WriteApi } from '@influxdata/influxdb-client'
 
@@ -380,6 +379,67 @@ export class V1Controller {
 
       return jsonrpc.error(reqRPCID, new JsonRpcError('Relay attempts exhausted', -32050))
     }
+  }
+
+  /**
+   * Load Balancers cannot be relayed through a GET request. Returns message to
+   * use POST method instead
+   * @param id Load Balancer ID
+   * @param rawData
+   * @param filter
+   * @returns
+   */
+  @get('/v1/lb/{id}')
+  async invalidLoadBalancerRelay(
+    @requestBody({
+      description: 'Relay Request',
+      required: true,
+      content: {
+        'application/json': {
+          // Skip body parsing
+          'x-parser': 'raw',
+        },
+      },
+    })
+    rawData: object
+  ): Promise<ErrorObject> {
+    return V1Controller.getInvalidRequestResponse(rawData || '')
+  }
+
+  /**
+   * Load Balancers cannot be relayed through a GET request. Returns message to
+   * use POST method instead
+   * @param id Load Balancer ID
+   * @param rawData
+   * @param filter
+   * @returns
+   */
+  @get('/v1/{id}')
+  async invalidApplicationRelay(
+    @requestBody({
+      description: 'Relay Request',
+      required: true,
+      content: {
+        'application/json': {
+          // Skip body parsing
+          'x-parser': 'raw',
+        },
+      },
+    })
+    rawData: object
+  ): Promise<ErrorObject> {
+    return V1Controller.getInvalidRequestResponse(rawData || '')
+  }
+
+  static getInvalidRequestResponse(rawData: object | string): ErrorObject {
+    const parsedRawData = parseRawData(rawData)
+
+    const reqRPCID = parseRPCID(parsedRawData)
+
+    return new ErrorObject(
+      reqRPCID,
+      new jsonrpc.JsonRpcError('GET requests are not supported. Use POST instead', -32067)
+    )
   }
 
   async checkClientStickiness(

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -791,4 +791,21 @@ describe('V1 controller (acceptance)', () => {
 
     expect(successStickyResponses).to.be.equal(4)
   })
+
+  it('Returns error on get request to app/lb', async () => {
+    ;({ app, client } = await setupApplication())
+
+    const appResponse = await client.get('/v1/abc1234').expect(200)
+    const lbResponse = await client.get('/v1/abc1234').expect(200)
+
+    console.log(appResponse.body)
+
+    const message = 'GET requests are not supported. Use POST instead'
+
+    expect(appResponse.body).to.have.properties('error', 'id', 'jsonrpc')
+    expect(appResponse.body.error.message).to.be.equal(message)
+
+    expect(lbResponse.body).to.have.properties('error', 'id', 'jsonrpc')
+    expect(lbResponse.body.error.message).to.be.equal(message)
+  })
 })


### PR DESCRIPTION
Returns a more explicit message when attempting to relay an application/load balancer using a GET request. Closes #563 