### PR TITLE
fix: cherry picker was saving appID instead of gigastakeID

### DIFF
--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -33,6 +33,7 @@ export class ChainChecker {
     pocketAAT,
     pocketConfiguration,
     pocketSession,
+    gigastakeAppID,
   }: ChainIDFilterOptions): Promise<CheckResult> {
     const sessionHash = hashBlockchainNodes(blockchainID, pocketSession.sessionNodes)
 
@@ -81,6 +82,7 @@ export class ChainChecker {
       sessionHash,
       pocketConfiguration,
       pocketSession,
+      gigastakeAppID,
     }
     const nodeChainLogs = await this.getNodeChainLogs(options)
 
@@ -193,6 +195,7 @@ export class ChainChecker {
     sessionHash,
     pocketConfiguration,
     pocketSession,
+    gigastakeAppID,
   }: GetNodesChainLogsOptions): Promise<NodeChainLog[]> {
     const nodeChainLogs: NodeChainLog[] = []
     const promiseStack: Promise<NodeChainLog>[] = []
@@ -219,6 +222,7 @@ export class ChainChecker {
         sessionHash,
         pocketConfiguration,
         pocketSession,
+        gigastakeAppID,
       }
 
       promiseStack.push(this.getNodeChainLog(options))
@@ -246,6 +250,7 @@ export class ChainChecker {
     pocketAAT,
     pocketConfiguration,
     pocketSession,
+    gigastakeAppID,
   }: GetNodeChainLogOptions): Promise<NodeChainLog> {
     const { sessionKey, sessionNodes } = pocketSession || {}
     // Pull the current block from each node using the blockchain's chainCheck as the relay
@@ -320,6 +325,7 @@ export class ChainChecker {
         .recordMetric({
           requestID: requestID,
           applicationID: applicationID,
+          gigastakeAppID,
           applicationPublicKey: applicationPublicKey,
           blockchainID,
           serviceNode: node.publicKey,
@@ -361,6 +367,7 @@ export class ChainChecker {
         .recordMetric({
           requestID: requestID,
           applicationID: applicationID,
+          gigastakeAppID,
           applicationPublicKey: applicationPublicKey,
           blockchainID,
           serviceNode: node.publicKey,
@@ -437,6 +444,7 @@ interface BaseChainLogOptions {
   pocketConfiguration: Configuration
   sessionHash: string
   pocketSession: Session
+  gigastakeAppID?: string
 }
 
 interface GetNodesChainLogsOptions extends BaseChainLogOptions {
@@ -459,4 +467,5 @@ export type ChainIDFilterOptions = {
   pocketAAT: PocketAAT
   pocketConfiguration: Configuration
   pocketSession: Session
+  gigastakeAppID?: string
 }

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -163,7 +163,7 @@ export class MetricsRecorder {
       if (serviceNode) {
         await this.cherryPicker.updateServiceQuality(
           blockchainID,
-          applicationID,
+          gigastakeAppID ? gigastakeAppID : applicationID,
           serviceNode,
           elapsedTime,
           result,

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -643,6 +643,7 @@ export class PocketRelayer {
         pocket: this.pocket,
         pocketConfiguration: this.pocketConfiguration,
         pocketSession,
+        gigastakeAppID: applicationID !== application.id ? application.id : undefined,
       }
 
       chainCheckPromise = this.chainChecker.chainIDFilter(chainIDOptions)
@@ -662,6 +663,7 @@ export class PocketRelayer {
         pocketAAT,
         pocketConfiguration: this.pocketConfiguration,
         pocketSession,
+        gigastakeAppID: applicationID !== application.id ? application.id : undefined,
       }
 
       syncCheckPromise = this.syncChecker.consensusFilter(consensusFilterOptions)

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -36,6 +36,7 @@ export class SyncChecker {
     pocketAAT,
     pocketConfiguration,
     pocketSession,
+    gigastakeAppID,
   }: ConsensusFilterOptions): Promise<CheckResult> {
     // Blockchain records passed in with 0 sync allowance are missing the 'syncAllowance' field in MongoDB
     syncCheckOptions.allowance = syncCheckOptions.allowance > 0 ? syncCheckOptions.allowance : this.defaultSyncAllowance
@@ -86,7 +87,8 @@ export class SyncChecker {
       pocketAAT,
       pocketConfiguration,
       sessionHash,
-      pocketSession
+      pocketSession,
+      gigastakeAppID
     )
 
     let errorState = false
@@ -245,7 +247,8 @@ export class SyncChecker {
         this.metricsRecorder
           .recordMetric({
             requestID: requestID,
-            applicationID: applicationID,
+            applicationID,
+            gigastakeAppID,
             applicationPublicKey: applicationPublicKey,
             blockchainID,
             serviceNode: nodeSyncLog.node.publicKey,
@@ -365,7 +368,8 @@ export class SyncChecker {
     pocketAAT: PocketAAT,
     pocketConfiguration: Configuration,
     sessionHash: string,
-    pocketSession: Session
+    pocketSession: Session,
+    gigastakeAppID?: string
   ): Promise<NodeSyncLog[]> {
     const nodeSyncLogs: NodeSyncLog[] = []
     const promiseStack: Promise<NodeSyncLog>[] = []
@@ -392,7 +396,8 @@ export class SyncChecker {
           pocketAAT,
           pocketConfiguration,
           sessionHash,
-          pocketSession
+          pocketSession,
+          gigastakeAppID
         )
       )
     }
@@ -419,7 +424,8 @@ export class SyncChecker {
     pocketAAT: PocketAAT,
     pocketConfiguration: Configuration,
     sessionHash: string,
-    pocketSession?: Session
+    pocketSession?: Session,
+    gigastakeAppID?: string
   ): Promise<NodeSyncLog> {
     const { sessionNodes } = pocketSession || {}
     // Pull the current block from each node using the blockchain's syncCheck as the relay
@@ -495,7 +501,8 @@ export class SyncChecker {
       this.metricsRecorder
         .recordMetric({
           requestID: requestID,
-          applicationID: applicationID,
+          applicationID,
+          gigastakeAppID,
           applicationPublicKey: applicationPublicKey,
           blockchainID,
           serviceNode: node.publicKey,
@@ -537,6 +544,7 @@ export class SyncChecker {
         .recordMetric({
           requestID: requestID,
           applicationID: applicationID,
+          gigastakeAppID,
           applicationPublicKey: applicationPublicKey,
           blockchainID,
           serviceNode: node.publicKey,
@@ -635,4 +643,5 @@ export type ConsensusFilterOptions = {
   pocketAAT: PocketAAT
   pocketConfiguration: Configuration
   pocketSession: Session
+  gigastakeAppID?: string
 }


### PR DESCRIPTION
With gigastakes, the cherry picker was saving the AppID instead of the gigastakeID, this lead to checking nodes of many different sessions saved under the same appID, leading to failure. With this when available, the cherry picker will save the gigastakeAppID and use it for sorting and picking the nodes