### PR TITLE
feat: don't update the instance on boot

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -16,6 +16,8 @@ import { InfluxDB } from '@influxdata/influxdb-client'
 import AatPlans from './config/aat-plans.json'
 import { DEFAULT_POCKET_CONFIG } from './config/pocket-config'
 import { GatewaySequence } from './sequence'
+import { POCKET_JS_INSTANCE_TIMEOUT_KEY, POCKET_JS_TIMEOUT_MAX, POCKET_JS_TIMEOUT_MIN } from './utils/constants'
+import { getRandomInt } from './utils/helpers'
 const logger = require('./services/logger')
 
 require('log-timestamp')
@@ -167,6 +169,14 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
           })
 
     this.bind('redisInstance').to(redis)
+
+    // This is to avoid updating the pocketjs instance right awaay on boot
+    await redis.set(
+      POCKET_JS_INSTANCE_TIMEOUT_KEY,
+      'true',
+      'EX',
+      getRandomInt(POCKET_JS_TIMEOUT_MIN, POCKET_JS_TIMEOUT_MAX)
+    )
 
     // New metrics postgres for error recording
     const psqlConnection: string = PSQL_CONNECTION || ''


### PR DESCRIPTION
Fix testing issue by not allowing the instance to be updated right away, this also helps the instance to not be set twice with no need