### PR TITLE
Stop pulling sessions with pocket-js

### DIFF
--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -616,8 +616,6 @@ export class PocketRelayer {
     const dispatchURL = `${dispatcher}v1/client/dispatch`
     const dispatchResponse = await axios.post(dispatchURL, dispatchRequestBody)
 
-    console.log('Dispatch Data:', dispatchResponse.data)
-
     if (dispatchResponse.status !== 200) {
       logger.log('error', `ERROR: obtaining a session: ${dispatchResponse.data}`, {
         relayType: 'APP',

--- a/src/services/pocket-rpc.ts
+++ b/src/services/pocket-rpc.ts
@@ -1,0 +1,86 @@
+import axios, { AxiosResponse } from 'axios'
+import { Node, Session, SessionHeader } from '@pokt-network/pocket-js'
+import { getRandomInt } from '../utils/helpers'
+import { DispatchNewSessionRequest, NodeAxiosResponse } from '../utils/types'
+
+const logger = require('../services/logger')
+
+export class PocketRPC {
+  dispatchers: URL[]
+
+  constructor(dispatchers: URL[]) {
+    this.dispatchers = dispatchers
+  }
+
+  async dispatchNewSession({
+    appPublicKey,
+    blockchainID,
+    sessionHeight = 0,
+    applicationID,
+    origin,
+    requestID,
+    retries = 3,
+  }: {
+    appPublicKey: string
+    blockchainID: string
+    sessionHeight?: number
+    applicationID?: string
+    origin?: string
+    requestID?: string
+    retries?: number
+  }): Promise<Session> {
+    let dispatcher: URL
+    let dispatchResponse: AxiosResponse
+
+    for (let attempts = 0; attempts < retries; attempts++) {
+      // Pocketjs session calls are more prone to timeouts when getting the dispatchers,
+      // Doing the rpc call directly minimizes the possibily of failing due to timeouts
+      dispatcher = this.pickRandomDispatcher()
+      const dispatchURL = `${dispatcher}v1/client/dispatch`
+
+      dispatchResponse = await axios.post(dispatchURL, {
+        app_public_key: appPublicKey,
+        chain: blockchainID,
+        session_height: sessionHeight,
+      } as DispatchNewSessionRequest)
+
+      if (dispatchResponse.status !== 200) {
+        logger.log('error', `ERROR: obtaining a session: ${dispatchResponse.data}`, {
+          relayType: 'APP',
+          typeID: applicationID,
+          origin,
+          blockchainID,
+          requestID,
+        })
+        continue
+      }
+
+      const sessionHeader = new SessionHeader(appPublicKey, blockchainID, BigInt(0))
+
+      // Converts the rpc response in a way that is compatible with pocketjs for
+      // sending relays through
+      const nodes: Node[] = (dispatchResponse.data.session.nodes as NodeAxiosResponse[]).map(PocketRPC.formatNode)
+
+      return new Session(sessionHeader, dispatchResponse.data.session.key, nodes)
+    }
+
+    throw new Error(`Error obtaining a session: ${dispatchResponse.data}`)
+  }
+
+  pickRandomDispatcher(): URL {
+    return this.dispatchers[getRandomInt(0, this.dispatchers.length)]
+  }
+
+  static formatNode(rawNode: NodeAxiosResponse): Node {
+    return new Node(
+      rawNode.address,
+      rawNode.public_key,
+      rawNode.jailed,
+      rawNode.status,
+      BigInt(rawNode.tokens),
+      rawNode.service_url,
+      rawNode.chains,
+      rawNode.unstakingTime
+    )
+  }
+}

--- a/src/services/pocket-rpc.ts
+++ b/src/services/pocket-rpc.ts
@@ -38,11 +38,15 @@ export class PocketRPC {
       dispatcher = this.pickRandomDispatcher()
       const dispatchURL = `${dispatcher}v1/client/dispatch`
 
-      dispatchResponse = await axios.post(dispatchURL, {
-        app_public_key: appPublicKey,
-        chain: blockchainID,
-        session_height: sessionHeight,
-      } as DispatchNewSessionRequest)
+      dispatchResponse = await axios.post(
+        dispatchURL,
+        {
+          app_public_key: appPublicKey,
+          chain: blockchainID,
+          session_height: sessionHeight,
+        } as DispatchNewSessionRequest,
+        { timeout: 2000 }
+      )
 
       if (dispatchResponse.status !== 200) {
         logger.log('error', `ERROR: obtaining a session: ${dispatchResponse.data}`, {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,4 @@
-import { HTTPMethod, Node } from '@pokt-network/pocket-js'
+import { HTTPMethod, Node, StakingStatus } from '@pokt-network/pocket-js'
 import { Applications } from '../models'
 import { SyncCheckOptions } from '../services/sync-checker'
 
@@ -41,4 +41,21 @@ export type StickinessOptions = {
 export type CheckResult = {
   nodes: Node[]
   cached: boolean
+}
+
+export type NodeAxiosResponse = {
+  address: string
+  chains: string[]
+  jailed: boolean
+  public_key: string
+  service_url: string
+  status: StakingStatus
+  tokens: string
+  unstakingTime: string
+}
+
+export type DispatchNewSessionRequest = {
+  app_public_key: string
+  chain: string
+  session_height: number
 }

--- a/tests/acceptance/test-helper.ts
+++ b/tests/acceptance/test-helper.ts
@@ -7,7 +7,7 @@ import { PocketGatewayApplication } from '../../src/application'
 import { DEFAULT_POCKET_CONFIG } from '../../src/config/pocket-config'
 import { gatewayTestDB } from '../fixtures/test.datasource'
 
-const DUMMY_ENV = {
+export const DUMMY_ENV = {
   NODE_ENV: 'development',
   GATEWAY_CLIENT_PRIVATE_KEY: 'v3rys3cr3tk3yud0nt3venkn0w',
   GATEWAY_CLIENT_PASSPHRASE: 'v3rys3cr3tp4ssphr4ze',
@@ -20,8 +20,7 @@ const DUMMY_ENV = {
   INFLUX_URL: 'http://influxdb:8086',
   INFLUX_TOKEN: 'abcde',
   INFLUX_ORG: 'myorg',
-  DISPATCH_URL:
-    'https://node1.mainnet.pokt.network,https://node2.mainnet.pokt.network,https://node3.mainnet.pokt.network,https://node4.mainnet.pokt.network,https://node5.mainnet.pokt.network,https://node6.mainnet.pokt.network,https://node7.mainnet.pokt.network,https://node8.mainnet.pokt.network,https://node9.mainnet.pokt.network,https://node10.mainnet.pokt.network,https://node11.mainnet.pokt.network,https://node12.mainnet.pokt.network,https://node13.mainnet.pokt.network,https://node14.mainnet.pokt.network,https://node15.mainnet.pokt.network,https://node16.mainnet.pokt.network,https://node17.mainnet.pokt.network,https://node18.mainnet.pokt.network,https://node19.mainnet.pokt.network,https://node20.mainnet.pokt.network',
+  DISPATCH_URL: 'https://node1.dispatcher.pokt.network/',
   ALTRUISTS: `{
     "0001": "https://user:pass@backups.example.org:18081",
     "0003": "https://user:pass@backups.example.org:19650",

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -7,8 +7,8 @@ import { ApplicationsRepository } from '../../src/repositories/applications.repo
 import { BlockchainsRepository } from '../../src/repositories/blockchains.repository'
 import { LoadBalancersRepository } from '../../src/repositories/load-balancers.repository'
 import { gatewayTestDB } from '../fixtures/test.datasource'
-import { MockRelayResponse, PocketMock } from '../mocks/pocketjs'
-import { setupApplication } from './test-helper'
+import { DEFAULT_NODES, MockRelayResponse, PocketMock } from '../mocks/pocketjs'
+import { DUMMY_ENV, setupApplication } from './test-helper'
 
 const logger = require('../../src/services/logger')
 
@@ -243,6 +243,38 @@ describe('V1 controller (acceptance)', () => {
     axiosMock = new MockAdapter(axios)
     axiosMock.onPost('https://user:pass@backups.example.org:18081/v1/query/node').reply(200, {
       service_url: 'https://localhost:443',
+    })
+    axiosMock.onPost(`${DUMMY_ENV.DISPATCH_URL}v1/client/dispatch`).reply(200, {
+      block_height: 1,
+      session: {
+        header: {
+          app_public_key: '1234567890',
+          chain: '0001',
+          session_height: 1,
+        },
+        key: '1234567890',
+        nodes: DEFAULT_NODES.map(
+          ({
+            address,
+            chains,
+            jailed,
+            publicKey: public_key,
+            serviceURL: service_url,
+            status,
+            stakedTokens: tokens,
+            unstakingCompletionTimestamp: unstaking_time,
+          }) => ({
+            address,
+            chains,
+            jailed,
+            public_key,
+            service_url,
+            status,
+            tokens: tokens.toString(),
+            unstaking_time,
+          })
+        ),
+      },
     })
   })
 

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -270,7 +270,7 @@ describe('Pocket relayer service (unit)', () => {
   it('loads all blockchains from db, caches them and returns config of requested blockchain', async () => {
     const dbBlockchains = await blockchainRepository.createAll(BLOCKCHAINS)
 
-    expect(dbBlockchains).to.be.length(3)
+    expect(dbBlockchains).to.have.length(3)
 
     const repositorySpy = sinon.spy(blockchainRepository, 'find')
     const redisGetSpy = sinon.spy(redis, 'get')

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -21,6 +21,7 @@ import { parseMethod } from '../../src/utils/parsing'
 import { updateConfiguration } from '../../src/utils/pocket'
 import { loadBlockchain } from '../../src/utils/relayer'
 import { CheckResult } from '../../src/utils/types'
+import { DUMMY_ENV } from '../acceptance/test-helper'
 import { gatewayTestDB } from '../fixtures/test.datasource'
 import { metricsRecorderMock } from '../mocks/metrics-recorder'
 import { DEFAULT_NODES, PocketMock } from '../mocks/pocketjs'
@@ -137,6 +138,8 @@ const APPLICATION = {
   },
 }
 
+const DISPATCHERS = DUMMY_ENV.DISPATCH_URL.split(',').map((dispatcher) => new URL(dispatcher))
+
 describe('Pocket relayer service (unit)', () => {
   let cherryPicker: CherryPicker
   let chainChecker: ChainChecker
@@ -186,11 +189,44 @@ describe('Pocket relayer service (unit)', () => {
       altruists: '{}',
       aatPlan: AatPlans.FREEMIUM,
       defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+      dispatchers: DISPATCHERS,
     })
 
     axiosMock = new MockAdapter(axios)
     axiosMock.onPost('https://user:pass@backups.example.org:18081/v1/query/node').reply(200, {
       service_url: 'https://localhost:443',
+    })
+    axiosMock.onPost(`${DUMMY_ENV.DISPATCH_URL}v1/client/dispatch`).reply(200, {
+      block_height: 1,
+      session: {
+        header: {
+          app_public_key: '1234567890',
+          chain: '0001',
+          session_height: 1,
+        },
+        key: '1234567890',
+        nodes: DEFAULT_NODES.map(
+          ({
+            address,
+            chains,
+            jailed,
+            publicKey: public_key,
+            serviceURL: service_url,
+            status,
+            stakedTokens: tokens,
+            unstakingCompletionTimestamp: unstaking_time,
+          }) => ({
+            address,
+            chains,
+            jailed,
+            public_key,
+            service_url,
+            status,
+            tokens: tokens.toString(),
+            unstaking_time,
+          })
+        ),
+      },
     })
   })
 
@@ -312,6 +348,7 @@ describe('Pocket relayer service (unit)', () => {
       altruists: '{}',
       aatPlan: AatPlans.FREEMIUM,
       defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+      dispatchers: DISPATCHERS,
     })
 
     const application = {
@@ -352,6 +389,7 @@ describe('Pocket relayer service (unit)', () => {
       altruists: '{}',
       aatPlan: AatPlans.FREEMIUM,
       defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+      dispatchers: DISPATCHERS,
     })
 
     const isInvalidApp = checkSecretKey(application as unknown as Applications, {
@@ -490,6 +528,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -544,6 +583,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -595,6 +635,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       try {
@@ -646,6 +687,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -694,6 +736,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -757,6 +800,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -849,6 +893,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -932,6 +977,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -985,6 +1031,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -1037,6 +1084,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -1088,6 +1136,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       rawData =
@@ -1139,6 +1188,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       rawData =
@@ -1196,6 +1246,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       const relayResponse = await poktRelayer.sendRelay({
@@ -1259,6 +1310,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       for (let i = 0; i <= 5; i++) {
@@ -1340,6 +1392,7 @@ describe('Pocket relayer service (unit)', () => {
         altruists: '{}',
         aatPlan: AatPlans.FREEMIUM,
         defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+        dispatchers: DISPATCHERS,
       })
 
       for (let i = 0; i <= 5; i++) {
@@ -1419,6 +1472,7 @@ describe('Pocket relayer service (unit)', () => {
           altruists: '{}',
           aatPlan: AatPlans.FREEMIUM,
           defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+          dispatchers: DISPATCHERS,
         })
 
         try {
@@ -1479,6 +1533,7 @@ describe('Pocket relayer service (unit)', () => {
           altruists: '{}',
           aatPlan: AatPlans.FREEMIUM,
           defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+          dispatchers: DISPATCHERS,
         })
 
         try {
@@ -1538,6 +1593,7 @@ describe('Pocket relayer service (unit)', () => {
           altruists: '{}',
           aatPlan: AatPlans.FREEMIUM,
           defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+          dispatchers: DISPATCHERS,
         })
 
         try {
@@ -1603,6 +1659,7 @@ describe('Pocket relayer service (unit)', () => {
           altruists: JSON.stringify(ALTRUISTS),
           aatPlan: AatPlans.FREEMIUM,
           defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+          dispatchers: DISPATCHERS,
         }) as PocketRelayer
 
         return poktRelayer

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -164,7 +164,6 @@ describe('Pocket relayer service (unit)', () => {
     blockchainRepository = new BlockchainsRepository(gatewayTestDB)
 
     pocketConfiguration = getPocketConfigOrDefault()
-
     pocketMock = new PocketMock(undefined, undefined, pocketConfiguration)
 
     const pocket = pocketMock.object()

--- a/tests/unit/pocket-rpc.unit.ts
+++ b/tests/unit/pocket-rpc.unit.ts
@@ -1,0 +1,66 @@
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { sinon, expect } from '@loopback/testlab'
+import { Session } from '@pokt-network/pocket-js'
+import { PocketRPC } from '../../src/services/pocket-rpc'
+import { DUMMY_ENV } from '../acceptance/test-helper'
+import { DEFAULT_NODES } from '../mocks/pocketjs'
+
+const DISPATCHERS = DUMMY_ENV.DISPATCH_URL.split(',').map((dispatcher) => new URL(dispatcher))
+
+describe('Pocket RPC (unit)', () => {
+  let axiosMock: MockAdapter
+
+  before('setup', async () => {
+    axiosMock = new MockAdapter(axios)
+    axiosMock.onPost(`${DUMMY_ENV.DISPATCH_URL}v1/client/dispatch`).reply(200, {
+      block_height: 1,
+      session: {
+        header: {
+          app_public_key: '1234567890',
+          chain: '0001',
+          session_height: 1,
+        },
+        key: '1234567890',
+        nodes: DEFAULT_NODES.map(
+          ({
+            address,
+            chains,
+            jailed,
+            publicKey: public_key,
+            serviceURL: service_url,
+            status,
+            stakedTokens: tokens,
+            unstakingCompletionTimestamp: unstaking_time,
+          }) => ({
+            address,
+            chains,
+            jailed,
+            public_key,
+            service_url,
+            status,
+            tokens: tokens.toString(),
+            unstaking_time,
+          })
+        ),
+      },
+    })
+  })
+
+  afterEach(async () => {
+    sinon.restore()
+  })
+
+  after(async () => {
+    axiosMock.restore()
+  })
+
+  it('successfully request a new session', async () => {
+    const pocketRPC = new PocketRPC(DISPATCHERS)
+
+    const session = await pocketRPC.dispatchNewSession({ appPublicKey: '000', blockchainID: '0021' })
+
+    expect(session).to.be.instanceOf(Session)
+    expect(session.sessionNodes).to.have.length(DEFAULT_NODES.length)
+  })
+})


### PR DESCRIPTION
Since we are now directly calling dispatchers, we no longer want to use pocket-js to pull nodes from session.