### PR TITLE
Extend sync check logic

### DIFF
--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -157,11 +157,10 @@ export class SyncChecker {
       errorState = true
     }
 
+    let isAltruistTrustworthy: boolean
+
     // Consult altruist for sync source of truth
     let altruistBlockHeight = await this.getSyncFromAltruist(syncCheckOptions, blockchainSyncBackup)
-
-    // Are nodes right or altruist right?
-    let isAltruistTrustworthy: boolean
 
     if (altruistBlockHeight === 0 || isNaN(altruistBlockHeight)) {
       // Failure to find sync from consensus and altruist

--- a/tests/unit/sync-checker.unit.ts
+++ b/tests/unit/sync-checker.unit.ts
@@ -559,7 +559,7 @@ describe('Sync checker service (unit)', () => {
       expect(expectedLog).to.be.true()
     })
 
-    it('passes sync check with altruist behind and all nodes ahead', async () => {
+    it('passes sync check with altruist behind and >80% nodes ahead', async () => {
       const nodes = DEFAULT_NODES
 
       axiosMock.onPost(ALTRUIST_URL['0021']).reply(200, '{ "id": 1, "jsonrpc": "2.0", "result": "0x64" }')


### PR DESCRIPTION
We marked altruist as trustworthy even if a lot of nodes in the session were ahead of it. This PR introduces a feature that calculates the percent of nodes that are ahead of altruists. If more than 80% of the nodes that are reporting a height above zero are ahead of altruist's block height, then we mark it as untrustworthy and trust nodes.
