### PR TITLE
feat: sync lock go altruist

### DIFF
--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -67,7 +67,7 @@ export class SyncChecker {
     const syncLock = await this.redis.get('lock-' + syncedNodesKey)
 
     if (syncLock) {
-      return { nodes, cached }
+      return { nodes: [], cached }
     } else {
       // Set lock as this thread checks the sync with 60 second ttl.
       // If any major errors happen below, it will retry the sync check every 60 seconds.


### PR DESCRIPTION
When the cache is locked, we return all nodes in the session without doing checks on them. This PR does not return any nodes, and that would trigger altruists to serve those requests until the cache is filled with valid check results.