### PR TITLE
fix: enable tls connection verification

### DIFF
--- a/.github/workflows/canary-ap-northeast-2.yml
+++ b/.github/workflows/canary-ap-northeast-2.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/canary-ca-central-1.yml
+++ b/.github/workflows/canary-ca-central-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/canary-eu-central-1.yml
+++ b/.github/workflows/canary-eu-central-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/canary-us-west-2.yml
+++ b/.github/workflows/canary-us-west-2.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-ap-east-1.yml
+++ b/.github/workflows/production-ap-east-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-ap-northeast-1.yml
+++ b/.github/workflows/production-ap-northeast-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-ap-northeast-2.yml
+++ b/.github/workflows/production-ap-northeast-2.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-ap-south-1.yml
+++ b/.github/workflows/production-ap-south-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-ap-southeast-1.yml
+++ b/.github/workflows/production-ap-southeast-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-ca-central-1.yml
+++ b/.github/workflows/production-ca-central-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-eu-central-1.yml
+++ b/.github/workflows/production-eu-central-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-eu-north-1.yml
+++ b/.github/workflows/production-eu-north-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-eu-south-1.yml
+++ b/.github/workflows/production-eu-south-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-eu-west-1.yml
+++ b/.github/workflows/production-eu-west-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-eu-west-2.yml
+++ b/.github/workflows/production-eu-west-2.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-eu-west-3.yml
+++ b/.github/workflows/production-eu-west-3.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-us-east-1.yml
+++ b/.github/workflows/production-us-east-1.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-us-east-2.yml
+++ b/.github/workflows/production-us-east-2.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/production-us-west-2.yml
+++ b/.github/workflows/production-us-west-2.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/staging-us-west-2.yml
+++ b/.github/workflows/staging-us-west-2.yml
@@ -42,7 +42,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 0
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/.github/workflows/testnet-us-west-2.yml
+++ b/.github/workflows/testnet-us-west-2.yml
@@ -41,7 +41,6 @@ jobs:
           envkey_POCKET_RELAY_RETRIES: 5
           envkey_DEFAULT_SYNC_ALLOWANCE: 5
           envkey_DEFAULT_LOG_LIMIT_BLOCKS: 10000
-          envkey_NODE_TLS_REJECT_UNAUTHORIZED: 0
           envkey_AAT_PLAN: premium
           envkey_NODE_ENV: production
           envkey_INFLUX_URL: https://influx.portal.pokt.network:8086

--- a/pocket-gateway/tasks/shared-envs.json
+++ b/pocket-gateway/tasks/shared-envs.json
@@ -53,10 +53,6 @@
       "value": 10000
     },
     {
-      "key": "NODE_TLS_REJECT_UNAUTHORIZED",
-      "value": 0
-    },
-    {
       "key": "AAT_PLAN",
       "value": "premium"
     },


### PR DESCRIPTION
The TLS verification was disabled at Node level. This was causing the server to connect to make insecure connections to HTTP endpoints. Our service should enforce HTTPS.