### PR TITLE
[DO NOT MERGE] fix: exclusion of synced nodes by sync checker

### DIFF
--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -62,7 +62,7 @@ export class ChainChecker {
     const ChainLock = await this.redis.get('lock-' + checkedNodesKey)
 
     if (ChainLock) {
-      return { nodes, cached }
+      return { nodes: [], cached }
     } else {
       // Set lock as this thread checks the Chain with 60 second ttl.
       // If any major errors happen below, it will retry the Chain check every 60 seconds.

--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -62,7 +62,7 @@ export class ChainChecker {
     const ChainLock = await this.redis.get('lock-' + checkedNodesKey)
 
     if (ChainLock) {
-      return { nodes: [], cached }
+      return { nodes, cached }
     } else {
       // Set lock as this thread checks the Chain with 60 second ttl.
       // If any major errors happen below, it will retry the Chain check every 60 seconds.

--- a/tests/unit/sync-checker.unit.ts
+++ b/tests/unit/sync-checker.unit.ts
@@ -740,48 +740,6 @@ describe('Sync checker service (unit)', () => {
       expect(expectedLog).to.be.true()
     })
 
-    it('pass session sync check excluding nodes that are too ahead of altruist', async () => {
-      const nodes = DEFAULT_NODES
-
-      const altruistHeightResult = '{ "id": 1, "jsonrpc": "2.0", "result": "0x10a0c7b" }' // 17435771
-
-      axiosMock.onPost(ALTRUIST_URL['0021']).reply(200, altruistHeightResult)
-
-      const firstNodeAhead = '{ "id": 1, "jsonrpc": "2.0", "result": "0x10a0cdf" }' // 17435871
-      const secondNodeAhead = '{ "id": 1, "jsonrpc": "2.0", "result": "0x10a0ce0" }' // 17435872
-
-      pocketMock.relayResponse[blockchains['0021'].syncCheckOptions.body] = [
-        firstNodeAhead,
-        secondNodeAhead,
-        altruistHeightResult,
-        altruistHeightResult,
-        altruistHeightResult,
-      ]
-
-      const pocketClient = pocketMock.object()
-
-      const { nodes: syncedNodes } = await syncChecker.consensusFilter({
-        nodes,
-        requestID: '1234',
-        blockchainID: blockchains['0021'].hash,
-        syncCheckOptions: blockchains['0021'].syncCheckOptions,
-        pocket: pocketClient,
-        applicationID: '',
-        applicationPublicKey: '',
-        blockchainSyncBackup: ALTRUIST_URL['0021'],
-        pocketAAT: undefined,
-        pocketConfiguration,
-        pocketSession: (await pocketClient.sessionManager.getCurrentSession(
-          undefined,
-          undefined,
-          undefined,
-          undefined
-        )) as Session,
-      })
-
-      expect(syncedNodes).to.have.length(3)
-    })
-
     it('fails agreement of three highest nodes', async () => {
       const nodes = DEFAULT_NODES
 


### PR DESCRIPTION
This PR introduces the following change:
- Sync check no longer favors altruists height as source of truth on a session with most of the nodes unsynced. This old behavior punished those nodes that were in sync, if altruist was also out of sync - as the majority of other nodes.
