### PR TITLE
feat: get blockchain by domain

### DIFF
--- a/src/utils/relayer.ts
+++ b/src/utils/relayer.ts
@@ -151,7 +151,7 @@ export async function getBlockchainAliasesByDomain(
   }
 
   const [blockchainFilter] = blockchains.filter((b: { redirects: BlockchainRedirect[] }) =>
-    b.redirects.some((rdr) => rdr.domain.toLowerCase() === host.toLowerCase())
+    b.redirects?.some((rdr) => rdr.domain.toLowerCase() === host.toLowerCase())
   )
 
   if (!blockchainFilter) {

--- a/src/utils/relayer.ts
+++ b/src/utils/relayer.ts
@@ -131,3 +131,38 @@ export async function loadBlockchain(
     blockchainRedirects,
   } as BlockchainDetails)
 }
+
+// Get blockchain's alias by it's redirect domain
+export async function getBlockchainAliasesByDomain(
+  host: string,
+  redis: Redis,
+  blockchainsRepository: BlockchainsRepository,
+  rpcID: number
+): Promise<{ blockchainAliases: string[] }> {
+  // Load the requested blockchain
+  const cachedBlockchains = await redis.get('blockchains')
+  let blockchains
+
+  if (!cachedBlockchains) {
+    blockchains = await blockchainsRepository.find()
+    await redis.set('blockchains', JSON.stringify(blockchains), 'EX', 60)
+  } else {
+    blockchains = JSON.parse(cachedBlockchains)
+  }
+
+  const [blockchainFilter] = blockchains.filter((b: { redirects: BlockchainRedirect[] }) =>
+    b.redirects.some((rdr) => rdr.domain.toLowerCase() === host.toLowerCase())
+  )
+
+  if (!blockchainFilter) {
+    throw new ErrorObject(rpcID, new jsonrpc.JsonRpcError(`Unable to find a blockchain with domain: ${host}`, -32057))
+  }
+
+  let blockchainAliases: string[]
+
+  if (blockchainFilter.blockchainAliases) {
+    blockchainAliases = blockchainFilter.blockchainAliases
+  }
+
+  return Promise.resolve({ blockchainAliases })
+}


### PR DESCRIPTION
The problem PR #728 was that it failed to fetch the blockchain when a simple URL hit. There wasn't a way to find a blockchain just by the domain.

This PR introduces a way to do this, tested locally and also in canary. It works like a charm. All of the errors for invalid domain disappeared.