### PR TITLE
fix: original app gateway settings not propagating

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -7,7 +7,7 @@ import { get, param, post, requestBody } from '@loopback/rest'
 import { Configuration, HTTPMethod, Pocket } from '@pokt-network/pocket-js'
 import { WriteApi } from '@influxdata/influxdb-client'
 
-import { Applications, LoadBalancers } from '../models'
+import { Applications, GatewaySettings, LoadBalancers } from '../models'
 import { StickinessOptions } from '../models/load-balancers.model'
 import { ApplicationsRepository, BlockchainsRepository, LoadBalancersRepository } from '../repositories'
 import { ChainChecker } from '../services/chain-checker'
@@ -233,11 +233,13 @@ export class V1Controller {
         originalAppID: string | undefined
         originalAppPK: string | undefined
         stickinessOptions: StickinessOptions | undefined
+        gatewaySettings: GatewaySettings | undefined
       } = {
         gigastaked: loadBalancer.gigastakeRedirect || false,
         originalAppID: undefined,
         originalAppPK: undefined,
         stickinessOptions: undefined,
+        gatewaySettings: undefined,
       }
 
       // Is this LB marked for gigastakeRedirect?
@@ -275,6 +277,7 @@ export class V1Controller {
             ? originalApp.freeTierApplicationAccount?.publicKey
             : originalApp.publicPocketAccount?.publicKey
           gigastakeOptions.stickinessOptions = originalApp?.stickinessOptions
+          gigastakeOptions.gatewaySettings = originalApp?.gatewaySettings
         }
       }
 
@@ -302,6 +305,10 @@ export class V1Controller {
 
       if (!application?.id) {
         throw new ErrorObject(reqRPCID, new jsonrpc.JsonRpcError('No application found in the load balancer', -32055))
+      }
+
+      if (gigastakeOptions?.gatewaySettings) {
+        application.gatewaySettings = gigastakeOptions.gatewaySettings
       }
 
       const options: SendRelayOptions = {

--- a/src/models/applications.model.ts
+++ b/src/models/applications.model.ts
@@ -108,7 +108,7 @@ type GatewayAAT = {
   applicationSignature: string
 }
 
-type GatewaySettings = {
+export type GatewaySettings = {
   whitelistOrigins: string[]
   whitelistUserAgents: string[]
   secretKeyRequired: boolean

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -475,8 +475,8 @@ describe('V1 controller (acceptance)', () => {
     appWithSecurity.gatewaySettings = {
       secretKey: 'securekey',
       secretKeyRequired: true,
-      whitelistOrigins: ['https://pokt.network'],
-      whitelistUserAgents: ['Mozilla/5.0'],
+      whitelistOrigins: [],
+      whitelistUserAgents: [],
     }
 
     await applicationsRepository.create(appWithSecurity)
@@ -490,8 +490,6 @@ describe('V1 controller (acceptance)', () => {
       .send({ method: 'eth_blockNumber', id: 1, jsonrpc: '2.0' })
       .set('Accept', 'application/json')
       .set('host', 'eth-mainnet-x')
-      .set('origin', 'https://pokt.network')
-      .set('user-agent', 'Mozilla/5.0')
       .expect(200)
 
     expect(response.headers).to.containDeep({ 'content-type': 'application/json' })

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -60,6 +60,12 @@ const GIGASTAKE_FOLLOWER_IDS = {
   lb: 'df9f9f9gdklkwotn5o3ixuso3od',
 }
 
+// Follower app that has restricted gateway settings
+const GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS = {
+  app: '5ifmwb6aq3frpgl9mqolike1xc',
+  lb: '0ab9z1so2g8x29xazaffse8ce',
+}
+
 // Might not actually reflect real-world values
 const BLOCKCHAINS = [
   {
@@ -109,7 +115,7 @@ const BLOCKCHAINS = [
       {
         alias: 'eth-mainnet',
         domain: 'eth-mainnet',
-        loadBalancerID: 'gt4a1s9rfrebaf8g31bsdc04',
+        loadBalancerID: GIGASTAKE_LEADER_IDS.lb,
       },
     ],
   },
@@ -236,6 +242,22 @@ const LOAD_BALANCERS = [
     name: 'gigastaked lb - follower',
     requestTimeout: 5000,
     applicationIDs: [GIGASTAKE_FOLLOWER_IDS.app],
+    logLimitBlocks: 25000,
+    gigastakeRedirect: true,
+    stickinessOptions: {
+      stickiness: true,
+      duration: 300,
+      useRPCID: false,
+      relaysLimit: 1e6,
+      stickyOrigins: ['localhost'],
+    },
+  },
+  {
+    id: GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS.lb,
+    user: 'test@test.com',
+    name: 'gigastaked lb - follower',
+    requestTimeout: 5000,
+    applicationIDs: [GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS.app],
     logLimitBlocks: 25000,
     gigastakeRedirect: true,
     stickinessOptions: {
@@ -445,6 +467,94 @@ describe('V1 controller (acceptance)', () => {
     expect(response.headers).to.containDeep({ 'content-type': 'application/json' })
     expect(response.body).to.have.property('error')
     expect(response.body.error.message).to.startWith('Whitelist Origin check failed')
+  })
+
+  it('fails on gigastake relay with invalid secret key', async () => {
+    const appWithSecurity = { ...APPLICATION, id: GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS.app }
+
+    appWithSecurity.gatewaySettings = {
+      secretKey: 'securekey',
+      secretKeyRequired: true,
+      whitelistOrigins: ['https://pokt.network'],
+      whitelistUserAgents: ['Mozilla/5.0'],
+    }
+
+    await applicationsRepository.create(appWithSecurity)
+
+    const pocket = pocketMock.object()
+
+    ;({ app, client } = await setupApplication(pocket))
+
+    const response = await client
+      .post(`/v1/lb/${GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS.lb}`)
+      .send({ method: 'eth_blockNumber', id: 1, jsonrpc: '2.0' })
+      .set('Accept', 'application/json')
+      .set('host', 'eth-mainnet-x')
+      .set('origin', 'https://pokt.network')
+      .set('user-agent', 'Mozilla/5.0')
+      .expect(200)
+
+    expect(response.headers).to.containDeep({ 'content-type': 'application/json' })
+    expect(response.body).to.have.property('error')
+    expect(response.body.error.message).to.startWith('SecretKey does not match')
+  })
+
+  it('fails on gigastake relay with invalid origin', async () => {
+    const appWithSecurity = { ...APPLICATION, id: GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS.app }
+
+    appWithSecurity.gatewaySettings = {
+      secretKey: '',
+      secretKeyRequired: false,
+      whitelistOrigins: ['https://pokt.network'],
+      whitelistUserAgents: [],
+    }
+
+    await applicationsRepository.create(appWithSecurity)
+
+    const pocket = pocketMock.object()
+
+    ;({ app, client } = await setupApplication(pocket))
+
+    const response = await client
+      .post(`/v1/lb/${GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS.lb}`)
+      .send({ method: 'eth_blockNumber', id: 1, jsonrpc: '2.0' })
+      .set('Accept', 'application/json')
+      .set('host', 'eth-mainnet-x')
+      .set('origin', 'https://poketo.network')
+      .expect(200)
+
+    expect(response.headers).to.containDeep({ 'content-type': 'application/json' })
+    expect(response.body).to.have.property('error')
+    expect(response.body.error.message).to.startWith('Whitelist Origin check failed')
+  })
+
+  it('fails on gigastake relay with invalid user agent', async () => {
+    const appWithSecurity = { ...APPLICATION, id: GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS.app }
+
+    appWithSecurity.gatewaySettings = {
+      secretKey: '',
+      secretKeyRequired: false,
+      whitelistOrigins: [],
+      whitelistUserAgents: ['Mozilla/5.0'],
+    }
+
+    await applicationsRepository.create(appWithSecurity)
+
+    const pocket = pocketMock.object()
+
+    ;({ app, client } = await setupApplication(pocket))
+
+    const response = await client
+      .post(`/v1/lb/${GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS.lb}`)
+      .send({ method: 'eth_blockNumber', id: 1, jsonrpc: '2.0' })
+      .set('Accept', 'application/json')
+      .set('host', 'eth-mainnet-x')
+      .set('user-agent', 'Chrome')
+      .expect(200)
+
+    expect(response.headers).to.containDeep({ 'content-type': 'application/json' })
+    expect(response.body).to.have.property('error')
+    expect(response.body.error.message).to.startWith('Whitelist User Agent check failed')
   })
 
   it('success relay with correct secret key, origin and userAgent security', async () => {


### PR DESCRIPTION
At this time, the original app gateway settings are not being propagated to the relayer. This basically ignores the settings for all gigastake redirected relays.