### PR TITLE
fix: remove duplicate log

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -410,13 +410,6 @@ export class V1Controller {
       let application = await this.fetchApplication(id, filter)
 
       if (!application?.id) {
-        logger.log('error', 'Application not found', {
-          requestID: this.requestID,
-          relayType: 'APP',
-          typeID: id,
-          serviceNode: '',
-          origin: this.origin,
-        })
         throw new ErrorObject(reqRPCID, new jsonrpc.JsonRpcError('Application not found', -32056))
       }
 


### PR DESCRIPTION
Application not found log is being duplicated. When the error is thrown, it's handled and logged, logging it there is no longer needed.