### PR TITLE
fix: applications without gigastake throwing err

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -429,8 +429,12 @@ export class V1Controller {
         ? await this.checkClientStickiness(rawData, stickyKeyPrefix, stickyOrigins, this.origin)
         : DEFAULT_STICKINESS_APP_PARAMS
 
-      const gigastakeApp = await this.getGigastakeApp(filter, '', reqRPCID)
-
+      let gigastakeApp: Applications
+      try {
+        gigastakeApp = await this.getGigastakeApp(filter, '', reqRPCID)
+      } catch {
+        // App chain doesn't have gigastake  available, Do nothing
+      }
       if (gigastakeApp) {
         gigastakeApp.gatewaySettings = application.gatewaySettings
         application = gigastakeApp


### PR DESCRIPTION
Applications without gigastake fail due to no gigastake lb found, this fixes it as not all chains have gigastake available 