### PR TITLE
fix: unsupported methods contract whitelisting

### DIFF
--- a/src/utils/evm/parsing.ts
+++ b/src/utils/evm/parsing.ts
@@ -3,23 +3,23 @@ import { parseMethod } from '../parsing'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function extractContractAddress(rawData: Record<string, any>): string | undefined {
-  const [firstParameter] = rawData.params
+  const params = rawData.params
   const method = parseMethod(rawData)
 
   switch (method) {
     case 'eth_sendRawTransaction':
-      return decodeEthRawTxAddress(firstParameter)
+      return decodeEthRawTxAddress(params[0])
     case 'eth_call':
       // firstParameter is the raw tx hex
-      return firstParameter?.to
+      return params[0]?.to
     case 'eth_getLogs':
-      return firstParameter?.address
+      return params[0]?.address
     case 'eth_getCode':
     case 'eth_getBalance':
     case 'eth_getStorageAt':
     case 'eth_getTransactionCount':
       // firstParameter is the address
-      return firstParameter
+      return params[0]
     default:
       // If the method is not supported, return undefined
       return undefined

--- a/src/utils/evm/whitelist.ts
+++ b/src/utils/evm/whitelist.ts
@@ -6,11 +6,13 @@ export function isMethodWhitelisted(method: string, whitelistedMethods: string[]
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isContractWhitelisted(rawData: Record<string, any>, whitelistedContracts: string[]) {
+export function isContractWhitelisted(rawData: Record<string, any>, whitelistedContracts: string[]): boolean {
   const contractAddress = extractContractAddress(rawData)
 
+  // This means that the method is not supported for this feature,
+  // so it shall pass.
   if (!contractAddress) {
-    return false
+    return true
   }
 
   return checkWhitelist(whitelistedContracts, contractAddress, 'explicit')


### PR DESCRIPTION
A small bug that restricted calls from unsupported methods while running the contract whitelist.