### PR TITLE
ref: better sync check logic readability

### DIFF
--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -248,7 +248,7 @@ export class SyncChecker {
         ? altruistBlockHeight + syncAllowance
         : highestNodeBlockHeight + syncAllowance
 
-      if (nodeSyncLog.blockHeight <= maximumBlockHeight && correctedNodeBlockHeight >= referenceBlockHeight) {
+      if (correctedNodeBlockHeight >= referenceBlockHeight && nodeSyncLog.blockHeight <= maximumBlockHeight) {
         logger.log('info', 'SYNC CHECK IN-SYNC: ' + node.publicKey + ' height: ' + blockHeight, {
           requestID: requestID,
           blockchainID,

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -218,10 +218,10 @@ export class SyncChecker {
 
         // Since we don't trust altruist, let's use highest node in session as reference
         referenceBlockHeight = highestNodeBlockHeight
-      } else {
-        // Altruist is trustworthy, so we use it as reference
-        referenceBlockHeight = altruistBlockHeight
       }
+
+      // Altruist is trustworthy, so we use it as reference
+      referenceBlockHeight = altruistBlockHeight
     }
 
     const isBlockHeightTooFar = highestNodeBlockHeight > altruistBlockHeight + syncAllowance

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -167,10 +167,11 @@ export class SyncChecker {
       errorState = true
     }
 
+    let referenceBlockHeight: number
     let isAltruistTrustworthy: boolean
 
     // Consult altruist for sync source of truth
-    let altruistBlockHeight = await this.getSyncFromAltruist(syncCheckOptions, blockchainSyncBackup)
+    const altruistBlockHeight = await this.getSyncFromAltruist(syncCheckOptions, blockchainSyncBackup)
 
     if (altruistBlockHeight === 0 || isNaN(altruistBlockHeight)) {
       // Failure to find sync from consensus and altruist
@@ -215,8 +216,11 @@ export class SyncChecker {
           }
         )
 
-        // Since we don't trust altruist, let's overwrite its block height
-        altruistBlockHeight = highestNodeBlockHeight
+        // Since we don't trust altruist, let's use highest node in session as reference
+        referenceBlockHeight = highestNodeBlockHeight
+      } else {
+        // Altruist is trustworthy, so we use it as reference
+        referenceBlockHeight = altruistBlockHeight
       }
     }
 
@@ -225,7 +229,7 @@ export class SyncChecker {
     // If altruist is trustworthy...
     // Make sure nodes aren't running too far ahead of altruist
     if (isAltruistTrustworthy && isBlockHeightTooFar) {
-      highestNodeBlockHeight = altruistBlockHeight
+      referenceBlockHeight = altruistBlockHeight
     }
 
     // Go through nodes and add all nodes that are current or within allowance -- this allows for block processing times
@@ -244,11 +248,7 @@ export class SyncChecker {
         ? altruistBlockHeight + syncAllowance
         : highestNodeBlockHeight + syncAllowance
 
-      if (
-        nodeSyncLog.blockHeight <= maximumBlockHeight &&
-        correctedNodeBlockHeight >= highestNodeBlockHeight &&
-        correctedNodeBlockHeight >= altruistBlockHeight
-      ) {
+      if (nodeSyncLog.blockHeight <= maximumBlockHeight && correctedNodeBlockHeight >= referenceBlockHeight) {
         logger.log('info', 'SYNC CHECK IN-SYNC: ' + node.publicKey + ' height: ' + blockHeight, {
           requestID: requestID,
           blockchainID,

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -224,14 +224,6 @@ export class SyncChecker {
       referenceBlockHeight = altruistBlockHeight
     }
 
-    const isBlockHeightTooFar = highestNodeBlockHeight > altruistBlockHeight + syncAllowance
-
-    // If altruist is trustworthy...
-    // Make sure nodes aren't running too far ahead of altruist
-    if (isAltruistTrustworthy && isBlockHeightTooFar) {
-      referenceBlockHeight = altruistBlockHeight
-    }
-
     // Go through nodes and add all nodes that are current or within allowance -- this allows for block processing times
     for (const nodeSyncLog of nodeSyncLogs) {
       const { node, blockHeight } = nodeSyncLog


### PR DESCRIPTION
This PR introduces a new variable called `referenceBlockHeight` to avoid overwriting `altruistBlockHeight` or `nodeBlockHeight` hence avoid confusion, and improve overall logic readability.