### PR TITLE
[develop] fix: eth_getLogs restriction failures & invalid node response

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,7 @@ If you ever get an error from the API, it will be in JSON-RPC format. This is ou
 | -32059 | Secret key does not match | Application's secret key doesn't match | non-standard |
 | -32060 | Whitelist origin check failed | Application configuration doesn't allow specified origin | non-standard |
 | -32061 | Whitelist user agent failed | Application configuration doesn't allow specified user-agent | non-standard |
-| -32062 | Try again with a explicit block number | eth_getLogs Limit Error | non-standard |
-| -32063 | Please use an explicit block number instead of 'latest' | eth_getLogs Limit Error | non-standard |
-| -32064 | You cannot query logs for more than X amount of blocks | eth_getLogs Limit Error | non-standard |
-| -32065 | Node returned an invalid response | The node serving your request returned an invalid response | non-standard |
+| -32064 | You cannot query logs for more than X amount of blocks | eth_getLogs Restriction Error | non-standard |
 | -32066 | The request body is not proper JSON | The request body couldn't be parsed | non-standard |
 | -32067 | GET requests are not supported. Use POST instead | Attempt to send a relay through a GET request | non-standard |
 

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -91,7 +91,7 @@ export class MetricsRecorder {
       let serviceDomain = ''
 
       if (session) {
-        const node = session.nodes.find((n) => n.publicKey === serviceNode)
+        const node = session.nodes?.find((n) => n.publicKey === serviceNode)
         if (node) {
           serviceURL = node.serviceUrl
           // @ts-ignore

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -271,10 +271,7 @@ export class PocketRelayer {
             // If the parsing goes wrong, we get a response with 'invalid' type and the following message.
             // We could get 'invalid' and not a parse error, hence we check both.
             if (parsedRelayResponse.type === 'invalid' && parsedRelayResponse.payload.message === 'Parse error') {
-              throw new ErrorObject(
-                rpcID,
-                new jsonrpc.JsonRpcError('Service Node returned an invalid response', -32065)
-              )
+              throw new Error('Service Node returned an invalid response')
             }
             // Check for user error to bubble these up to the API
             let userErrorMessage = ''
@@ -392,6 +389,7 @@ export class PocketRelayer {
 
       // Any other error (e.g parsing errors) that should not be propagated as response
       logger.log('error', 'POCKET RELAYER ERROR: ' + e, {
+        blockchainID,
         requestID,
         relayType: 'APP',
         typeID: application.id,

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -209,7 +209,7 @@ export class PocketRelayer {
         blockchainID,
         requestID,
         relayType: 'APP',
-        error: `${restriction.serialize()}`,
+        error: `${restriction.error.message}`,
         typeID: application.id,
         origin: this.origin,
       })

--- a/src/utils/evm/get-logs.ts
+++ b/src/utils/evm/get-logs.ts
@@ -51,7 +51,7 @@ export async function enforceGetLogs(
         fromBlock = latestBlock
       }
     } catch (e) {
-      logger.log('error', `Altruist unavailable: (${altruistURL})`, {
+      logger.log('error', `Altruist is not responding: (${altruistURL})`, {
         blockchainID,
         requestID,
       })

--- a/src/utils/evm/get-logs.ts
+++ b/src/utils/evm/get-logs.ts
@@ -15,23 +15,19 @@ export async function enforceGetLogs(
 ): Promise<ErrorObject | undefined> {
   let toBlock: number
   let fromBlock: number
-  let isToBlockHex = false
-  let isFromBlockHex = false
   const [{ fromBlock: fromBlockParam, toBlock: toBlockParam }] = parsedRawData.params as [
     { fromBlock: string; toBlock: string }
   ]
 
   if (toBlockParam !== undefined && toBlockParam !== 'latest') {
     toBlock = blockHexToDecimal(toBlockParam)
-    isToBlockHex = true
   }
   if (fromBlockParam !== undefined && fromBlockParam !== 'latest') {
     fromBlock = blockHexToDecimal(fromBlockParam)
-    isFromBlockHex = true
   }
 
-  if ((toBlock !== 0 || fromBlock !== 0) && altruistURL) {
-    // Altruist
+  // If any of the blocks is 'latest', we check altruists for latest height.
+  if (isNaN(toBlock) || isNaN(fromBlock)) {
     // TODO: use a generic getHeightFromAltruist function to fetch altruist block height
     const rawData = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_blockNumber' })
 
@@ -47,31 +43,21 @@ export async function enforceGetLogs(
 
       const latestBlock = blockHexToDecimal(data.result)
 
-      if (!isToBlockHex) {
+      if (isNaN(toBlock)) {
         toBlock = latestBlock
       }
-      if (!isFromBlockHex) {
+
+      if (isNaN(fromBlock)) {
         fromBlock = latestBlock
       }
     } catch (e) {
-      logger.log('error', `(eth_getLogs) Altruist unavailable: (${altruistURL})`, {
+      logger.log('error', `Altruist unavailable: (${altruistURL})`, {
         blockchainID,
         requestID,
       })
-      return jsonrpc.error(
-        rpcID,
-        new jsonrpc.JsonRpcError(`(eth_getLogs) Try again with a explicit block number`, -32062)
-      ) as ErrorObject
-    }
-  } else {
-    // We cannot move forward if there is no altruist available.
-    if (!isToBlockHex || !isFromBlockHex) {
-      return jsonrpc.error(
-        rpcID,
-        new jsonrpc.JsonRpcError(`(eth_getLogs) Please use an explicit block number instead of 'latest'.`, -32063)
-      ) as ErrorObject
     }
   }
+
   if (toBlock - fromBlock > logLimitBlocks) {
     return jsonrpc.error(
       rpcID,

--- a/src/utils/evm/get-logs.ts
+++ b/src/utils/evm/get-logs.ts
@@ -61,10 +61,7 @@ export async function enforceGetLogs(
   if (toBlock - fromBlock > logLimitBlocks) {
     return jsonrpc.error(
       rpcID,
-      new jsonrpc.JsonRpcError(
-        `(eth_getLogs) You cannot query logs for more than ${logLimitBlocks} blocks at once.`,
-        -32064
-      )
+      new jsonrpc.JsonRpcError(`You cannot query logs for more than ${logLimitBlocks} blocks at once.`, -32064)
     ) as ErrorObject
   }
 }

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -1105,57 +1105,7 @@ describe('Pocket relayer service (unit)', () => {
         relayRetries: 0,
       })) as ErrorObject
 
-      expect(relayResponse.error.message).to.match(/Try again with a explicit block number/)
-    })
-
-    it('should return an error if `eth_getLogs` call uses "latest" on block params (no altruist)', async () => {
-      const mock = new PocketMock()
-
-      mock.fail = true
-
-      const relayer = mock.object()
-
-      const poktRelayer = new PocketRelayer({
-        host: 'eth-mainnet',
-        origin: '',
-        userAgent: '',
-        ipAddress: '',
-        relayer,
-        cherryPicker,
-        metricsRecorder,
-        syncChecker,
-        chainChecker,
-        cache,
-        databaseEncryptionKey: DB_ENCRYPTION_KEY,
-        secretKey: '',
-        relayRetries: 0,
-        blockchainsRepository: blockchainRepository,
-        checkDebug: true,
-        aatPlan: AatPlans.FREEMIUM,
-        defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
-        dispatchers: DUMMY_ENV.DISPATCH_URL,
-      })
-
-      rawData =
-        '{"method":"eth_getLogs","params":[{"fromBlock":"latest","toBlock":"latest","address":"0xdef1c0ded9bec7f1a1670819833240f027b25eff"}],"id":1,"jsonrpc":"2.0"}'
-
-      const relayResponse = (await poktRelayer.sendRelay({
-        rawData,
-        relayPath: '',
-        httpMethod: HTTPMethod.POST,
-        application: APPLICATION as unknown as Applications,
-        requestID: '1234',
-        requestTimeOut: undefined,
-        overallTimeOut: undefined,
-        stickinessOptions: {
-          stickiness: false,
-          duration: 0,
-          preferredNodeAddress: '',
-        },
-        relayRetries: 0,
-      })) as ErrorObject
-
-      expect(relayResponse.error.message).to.match(/Try again with a explicit block number/)
+      expect(relayResponse.error.message).to.match(/You cannot query logs for more than/)
     })
 
     it('should succeed if `eth_getLogs` call is within permitted blocks range (no altruist)', async () => {
@@ -1208,8 +1158,7 @@ describe('Pocket relayer service (unit)', () => {
         relayRetries: 0,
       })) as ErrorObject
 
-      expect(relayResponse.error.message).to.match(/Try again with a explicit block number/)
-      // expect(relayResponse).to.be.deepEqual(JSON.parse(mock.relayResponse[rawData] as string))
+      expect(relayResponse).to.be.deepEqual(JSON.parse(mock.relayResponse[rawData] as string))
     })
 
     it('relay requesting a preferred node should use that one if available with rpcID', async () => {


### PR DESCRIPTION
This PR fixes two things:

1. As of now, if our altruist were not reachable during the eth_getLogs restrictions, we would propagate an error to the user and have them not use 'latest' as an option. 

This behavior is quite overkill for the purpose of this feature, and if our altruists are having a bad time then all of the systems relaying on us, and using 'latest' would take a hit until they are back up.

Solution: if we altruist is unreachable, ignore this restriction and let the relay pass with 'latest' flag. The worse that can happen is having a request from 0 to latest, but that's restricted if our altruist is up. 

2. Invalid node responses were being propagated to the user instead of being exclusively logged and fallback to an altruist. There's no point on propagating this error to the user, it's better to only log this for our use and let an altruist serve it.