### PR TITLE
fix: handle restriction not found

### DIFF
--- a/src/utils/evm/restrictions.ts
+++ b/src/utils/evm/restrictions.ts
@@ -30,7 +30,7 @@ export async function enforceEVMRestrictions(
   if (application?.gatewaySettings?.whitelistMethods?.length > 0) {
     const restriction = application.gatewaySettings.whitelistMethods.find((x) => x.blockchainID === blockchainID)
 
-    const enforced = isMethodWhitelisted(method, restriction.methods)
+    const enforced = isMethodWhitelisted(method, restriction?.methods)
 
     if (!enforced) {
       return jsonrpc.error(
@@ -43,7 +43,7 @@ export async function enforceEVMRestrictions(
   if (application?.gatewaySettings?.whitelistContracts?.length > 0) {
     const restriction = application.gatewaySettings.whitelistContracts.find((x) => x.blockchainID === blockchainID)
 
-    const enforced = isContractWhitelisted(parsedRawData, restriction.contracts)
+    const enforced = isContractWhitelisted(parsedRawData, restriction?.contracts)
 
     if (!enforced) {
       return jsonrpc.error(


### PR DESCRIPTION
When using a LB with restricted whitelist, but using an unrestricted chain - it would return 204. Expected behavior is to make a successful request is the requested chain doesn't have any restriction. 

Added a pair of test cases to wrap that scenario.