### PR TITLE
Cherry-picker-changes

### DIFF
--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -9,7 +9,7 @@ import extractDomain from 'extract-domain'
 import { MetricsRecorder } from '../services/metrics-recorder'
 import { blockHexToDecimal } from '../utils/block'
 import { removeChecksCache, removeNodeFromSession, removeSessionCache } from '../utils/cache'
-import { CHECK_TIMEOUT, PERCENTAGE_THRESHOLD_TO_REMOVE_SESSION } from '../utils/constants'
+import { CheckMethods, CHECK_TIMEOUT, PERCENTAGE_THRESHOLD_TO_REMOVE_SESSION } from '../utils/constants'
 import { checkEnforcementJSON } from '../utils/enforcements'
 import { CheckResult, RelayResponse } from '../utils/types'
 import { Cache } from './cache'
@@ -335,7 +335,7 @@ export class ChainChecker {
           result: 500,
           bytes: Buffer.byteLength('WRONG CHAIN', 'utf8'),
           fallback: false,
-          method: 'chaincheck',
+          method: CheckMethods.ChainCheck,
           error: typeof relay.message === 'object' ? JSON.stringify(relay.message) : relay.message,
           code: undefined,
           origin: this.origin,
@@ -372,7 +372,7 @@ export class ChainChecker {
           result: 500,
           bytes: Buffer.byteLength('WRONG CHAIN', 'utf8'),
           fallback: false,
-          method: 'chaincheck',
+          method: CheckMethods.ChainCheck,
           error: JSON.stringify(relay),
           code: undefined,
           origin: this.origin,

--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -216,7 +216,7 @@ export class CherryPicker {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let serviceQuality: {
-      results: any
+      results: unknown
       medianSuccessLatency: string
       weightedSuccessLatency: string
       sessionKey: string

--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -83,7 +83,7 @@ export class CherryPicker {
     // Iterate through sorted logs and form in to a weighted list
     let rankedItems = await this.rankItems(blockchain, sortedLogs, 50)
 
-    // If we have no nodes left because all are failures, ¯\_(ツ)_/¯
+    // If we have no nodes left it's because all are failures, ¯\_(ツ)_/¯
     if (rankedItems.length === 0) {
       logger.log('warn', 'Cherry picking failure -- nodes', {
         requestID: requestID,

--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -214,7 +214,6 @@ export class CherryPicker {
     // Pull the full service log including weighted latency and success rate
     const serviceLog = await this.fetchRawServiceLog(blockchain, id)
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let serviceQuality: {
       results: unknown
       medianSuccessLatency: string

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -218,6 +218,7 @@ export class MetricsRecorder {
         code,
       ]
 
+      // Consumed by the cherry picker external api, not used within this project atm
       if (serviceNode && result === 200) {
         await this.redis.incr(`${blockchainID}-${serviceNode}-${session.key}-success-hits`)
         await this.redis.expire(`${blockchainID}-${serviceNode}-${session.key}-success-hits`, 60 * 60)

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -171,15 +171,7 @@ export class MetricsRecorder {
 
       // Update service node quality with cherry picker
       if (serviceNode) {
-        await this.cherryPicker.updateServiceQuality(
-          blockchainID,
-          applicationID,
-          serviceNode,
-          elapsedTime,
-          result,
-          timeout,
-          session
-        )
+        await this.cherryPicker.updateServiceQuality(blockchainID, serviceNode, elapsedTime, result, session, timeout)
       }
 
       // Text timestamp

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -218,6 +218,11 @@ export class MetricsRecorder {
         code,
       ]
 
+      if (serviceNode && result === 200) {
+        await this.redis.incr(`${blockchainID}-${serviceNode}-${session.key}-success-hits`)
+        await this.redis.expire(`${blockchainID}-${serviceNode}-${session.key}-success-hits`, 60 * 60)
+      }
+
       // Increment node errors
       if (result !== 200) {
         // TODO: FIND Better way to check for valid service nodes (public key)

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -8,7 +8,7 @@ import { Pool as PGPool } from 'pg'
 import pgFormat from 'pg-format'
 import { Point, WriteApi } from '@influxdata/influxdb-client'
 
-import { BLOCK_TIMING_ERROR } from '../utils/constants'
+import { BLOCK_TIMING_ERROR, CheckMethods } from '../utils/constants'
 import { CherryPicker } from './cherry-picker'
 const os = require('os')
 const logger = require('../services/logger')
@@ -170,7 +170,7 @@ export class MetricsRecorder {
       }
 
       // Update service node quality with cherry picker
-      if (serviceNode) {
+      if (serviceNode && !Object.values(CheckMethods).includes(method as CheckMethods)) {
         await this.cherryPicker.updateServiceQuality(blockchainID, serviceNode, elapsedTime, result, session, timeout)
       }
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -830,7 +830,7 @@ export class PocketRelayer {
     }
 
     if (!node) {
-      node = await this.cherryPicker.cherryPickNode(application, nodes, blockchainID, requestID)
+      node = await this.cherryPicker.cherryPickNode(application, nodes, blockchainID, requestID, session.key)
     }
 
     if (this.checkDebug) {

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -830,7 +830,7 @@ export class PocketRelayer {
     }
 
     if (!node) {
-      node = await this.cherryPicker.cherryPickNode(application, nodes, blockchainID, requestID, key)
+      node = await this.cherryPicker.cherryPickNode(application, nodes, blockchainID, requestID)
     }
 
     if (this.checkDebug) {

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -10,7 +10,7 @@ import extractDomain from 'extract-domain'
 import { MetricsRecorder } from '../services/metrics-recorder'
 import { blockHexToDecimal } from '../utils/block'
 import { removeNodeFromSession, removeSessionCache, removeChecksCache } from '../utils/cache'
-import { CHECK_TIMEOUT, PERCENTAGE_THRESHOLD_TO_REMOVE_SESSION } from '../utils/constants'
+import { CheckMethods, CHECK_TIMEOUT, PERCENTAGE_THRESHOLD_TO_REMOVE_SESSION } from '../utils/constants'
 import { checkEnforcementJSON } from '../utils/enforcements'
 import { CheckResult, RelayResponse } from '../utils/types'
 import { Cache } from './cache'
@@ -279,7 +279,7 @@ export class SyncChecker {
             result: 500,
             bytes: Buffer.byteLength('OUT OF SYNC', 'utf8'),
             fallback: false,
-            method: 'synccheck',
+            method: CheckMethods.SyncCheck,
             error: `OUT OF SYNC: current block height on chain ${blockchainID}: ${highestNodeBlockHeight} - altruist block height: ${altruistBlockHeight} - nodes height: ${blockHeight} - sync allowance: ${syncAllowance}`,
             code: undefined,
             origin: this.origin,
@@ -515,7 +515,7 @@ export class SyncChecker {
           result: 500,
           bytes: Buffer.byteLength(relay.message, 'utf8'),
           fallback: false,
-          method: 'synccheck',
+          method: CheckMethods.SyncCheck,
           error: typeof relay.message === 'object' ? JSON.stringify(relay.message) : relay.message,
           code: undefined,
           origin: this.origin,
@@ -552,7 +552,7 @@ export class SyncChecker {
           result: 500,
           bytes: Buffer.byteLength('SYNC CHECK', 'utf8'),
           fallback: false,
-          method: 'synccheck',
+          method: CheckMethods.SyncCheck,
           error: JSON.stringify(relay),
           code: undefined,
           origin: this.origin,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -16,3 +16,8 @@ export const CHECK_TIMEOUT = 4000
 export const DEFAULT_ALTRUIST_TIMEOUT = 60000 // Milliseconds
 
 export const PERCENTAGE_THRESHOLD_TO_REMOVE_SESSION = 0.7
+
+export enum CheckMethods {
+  SyncCheck = 'synchceck',
+  ChainCheck = 'chaincheck',
+}

--- a/tests/mocks/pocketjs.ts
+++ b/tests/mocks/pocketjs.ts
@@ -60,7 +60,7 @@ export const DEFAULT_NODES: Node[] = [
 ]
 
 // Default values to use for request/response objects
-const DEFAULT_MOCK_VALUES = {
+export const DEFAULT_MOCK_VALUES = {
   DISPATCHERS: [
     new URL('https://node1.dispatcher.pokt.network'),
     new URL('https://node2.dispatcher.pokt.network'),

--- a/tests/unit/cherry-picker.unit.ts
+++ b/tests/unit/cherry-picker.unit.ts
@@ -3,7 +3,7 @@ import RedisMock from 'ioredis-mock'
 import { expect } from '@loopback/testlab'
 import { Applications } from '../../src/models'
 import { CherryPicker } from '../../src/services/cherry-picker'
-import { PocketMock } from '../mocks/pocketjs'
+import { DEFAULT_MOCK_VALUES, PocketMock } from '../mocks/pocketjs'
 
 describe('Cherry picker service (unit)', () => {
   let cherryPicker: CherryPicker
@@ -243,6 +243,7 @@ describe('Cherry picker service (unit)', () => {
       const expectedLogs = JSON.stringify({
         medianSuccessLatency: '0.00000',
         weightedSuccessLatency: '0.00000',
+        sessionKey: DEFAULT_MOCK_VALUES.SESSION.key,
         results: {
           [result]: 1,
         },

--- a/tests/unit/cherry-picker.unit.ts
+++ b/tests/unit/cherry-picker.unit.ts
@@ -253,7 +253,9 @@ describe('Cherry picker service (unit)', () => {
       logs = await redis.get(`{${blockchain}}-${id}-service`)
       expect(logs).to.be.null()
 
-      await cherryPicker.updateServiceQuality(blockchain, 'appID', id, elapseTime, result)
+      const session = await new PocketMock().object().getNewSession(undefined)
+
+      await cherryPicker.updateServiceQuality(blockchain, id, elapseTime, result, session)
 
       logs = await redis.get(`{${blockchain}}-${id}-service`)
       expect(JSON.parse(logs)).to.be.deepEqual(JSON.parse(expectedLogs))
@@ -281,8 +283,9 @@ describe('Cherry picker service (unit)', () => {
         'EX',
         60
       )
+      const session = await new PocketMock().object().getNewSession(undefined)
 
-      await cherryPicker.updateServiceQuality(blockchain, 'appID', id, elapseTime, result)
+      await cherryPicker.updateServiceQuality(blockchain, id, elapseTime, result, session)
       const logs = await redis.get(`{${blockchain}}-${id}-service`)
 
       expect(JSON.parse(logs)).to.be.deepEqual(JSON.parse(expectedLogs))
@@ -405,7 +408,7 @@ describe('Cherry picker service (unit)', () => {
         failure: true,
       },
     ]
-    const sortedLogs = cherryPicker.sortLogs(unsortedLogs, '1234', '1234', '1234')
+    const sortedLogs = cherryPicker.sortLogs(unsortedLogs)
 
     expect(sortedLogs).to.be.deepEqual(expectedSortedLogs)
   })


### PR DESCRIPTION
Several changes on the cherry picker service, nothing affects they way the results are calculated. Some of them include

* Fix typos and old comments pointing out to info not accurate anymore
* Remove unused fields on methods and places were used to send them

Fixed the error where the checks errors were taking into account for the cherry picker results.

And at last added in metrics recorder a ephemeral store of node relay successes to be consumed externally  