### PR TITLE
Add more data to cherry picker

### DIFF
--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -219,6 +219,7 @@ export class CherryPicker {
       medianSuccessLatency: string
       weightedSuccessLatency: string
       sessionKey: string
+      sessionHeight: string | number
     }
 
     // Update service quality log for this time period
@@ -268,6 +269,7 @@ export class CherryPicker {
         medianSuccessLatency: elapsedTime.toFixed(5),
         weightedSuccessLatency: elapsedTime.toFixed(5),
         sessionKey: session.key,
+        sessionHeight: session.header.sessionBlockHeight,
       }
     }
 

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -224,7 +224,7 @@ export class MetricsRecorder {
         await this.redis.expire(`${blockchainID}-${serviceNode}-${session.key}-success-hits`, 60 * 60)
       } else if (serviceNode && result !== 200) {
         await this.redis.incr(`${blockchainID}-${serviceNode}-${session.key}-failure-hits`)
-        await this.redis.expire(`${blockchainID}-${serviceNode}-${session.key}-success-hits`, 60 * 60)
+        await this.redis.expire(`${blockchainID}-${serviceNode}-${session.key}-failure-hits`, 60 * 60)
       }
 
       // Increment node errors

--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -222,6 +222,9 @@ export class MetricsRecorder {
       if (serviceNode && result === 200) {
         await this.redis.incr(`${blockchainID}-${serviceNode}-${session.key}-success-hits`)
         await this.redis.expire(`${blockchainID}-${serviceNode}-${session.key}-success-hits`, 60 * 60)
+      } else if (serviceNode && result !== 200) {
+        await this.redis.incr(`${blockchainID}-${serviceNode}-${session.key}-failure-hits`)
+        await this.redis.expire(`${blockchainID}-${serviceNode}-${session.key}-success-hits`, 60 * 60)
       }
 
       // Increment node errors

--- a/tests/unit/cherry-picker.unit.ts
+++ b/tests/unit/cherry-picker.unit.ts
@@ -244,6 +244,7 @@ describe('Cherry picker service (unit)', () => {
         medianSuccessLatency: '0.00000',
         weightedSuccessLatency: '0.00000',
         sessionKey: DEFAULT_MOCK_VALUES.SESSION.key,
+        sessionHeight: DEFAULT_MOCK_VALUES.SESSION.header.sessionBlockHeight,
         results: {
           [result]: 1,
         },


### PR DESCRIPTION
Small PR on more data to save on the cherry picker service logs, also record failure relays in a cache counter