### PR TITLE
fix: simple redirect controller

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -157,7 +157,11 @@ export class V1Controller {
           // Modify the host using the stored blockchain name in DB
           this.pocketRelayer.host = redirect.alias
           this.host = redirect.alias
-          return await this.loadBalancerRelay(`${redirect.loadBalancerID}${blockchainPath}`, rawData)
+
+          // convert the slashes to tildes for processing in the loadBalancerRelay route
+          const lbID = `${redirect.loadBalancerID}${blockchainPath}`.replace(/\//gi, '~')
+
+          return await this.loadBalancerRelay(lbID, rawData)
         }
       }
     } catch (e) {

--- a/src/utils/evm/get-logs.ts
+++ b/src/utils/evm/get-logs.ts
@@ -51,7 +51,7 @@ export async function enforceGetLogs(
         fromBlock = latestBlock
       }
     } catch (e) {
-      logger.log('error', `Altruist is not responding: (${altruistURL})`, {
+      logger.log('error', `Altruist is not responding: ${altruistURL.replace(/[\w]*:\/\/[^\/]*@/g, '')}`, {
         blockchainID,
         requestID,
       })

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -55,18 +55,18 @@ const APPLICATION = {
 }
 
 const GIGASTAKE_LEADER_IDS = {
-  app: 'dofwms0cosmasiqqoadldfisdsf',
-  lb: 'hovj6nfix1nr0dknadwawawaqo',
+  app: 'dofwms0cosmasiqqoadldfis',
+  lb: 'hovj6nfix1nr0dknadwawawa',
 }
 const GIGASTAKE_FOLLOWER_IDS = {
-  app: 'asassd9sd0ffjdcusue2fidisss',
-  lb: 'df9f9f9gdklkwotn5o3ixuso3od',
+  app: 'asassd9sd0ffjdcusue2fidi',
+  lb: 'df9f9f9gdklkwotn5o3ixuso',
 }
 
 // Follower app that has restricted gateway settings
 const GIGASTAKE_FOLLOWER_IDS_WITH_RESTRICTIONS = {
-  app: '5ifmwb6aq3frpgl9mqolike1xc',
-  lb: '0ab9z1so2g8x29xazaffse8ce',
+  app: '5ifmwb6aq3frpgl9mqolike1',
+  lb: '0ab9z1so2g8x29xazaffse8c',
 }
 
 // Might not actually reflect real-world values
@@ -166,8 +166,8 @@ const BLOCKCHAINS = [
 
 const APPLICATIONS = [
   APPLICATION,
-  { ...APPLICATION, id: 'fg5fdj31d714kdif9g9fe68foth' },
-  { ...APPLICATION, id: 'cienuohoddigue4w232s9rjafgx' },
+  { ...APPLICATION, id: 'fg5fdj31d714kdif9g9fe68f' },
+  { ...APPLICATION, id: 'cienuohoddigue4w232s9rja' },
   { ...APPLICATION, id: GIGASTAKE_LEADER_IDS.app },
   { ...APPLICATION, id: GIGASTAKE_FOLLOWER_IDS.app },
 ]
@@ -210,7 +210,7 @@ const LOAD_BALANCERS = [
     },
   },
   {
-    id: 'd8ejd7834ht9d9sj345gfsoaao',
+    id: 'd8ejd7834ht9d9sj345gfsoa',
     user: 'test@test.com',
     name: 'test load balancer sticky prefix with whitelist',
     requestTimeout: 5000,
@@ -949,7 +949,7 @@ describe('V1 controller (acceptance)', () => {
 
     for (let i = 1; i <= 5; i++) {
       const response = await client
-        .post('/v1/lb/d8ejd7834ht9d9sj345gfsoaao')
+        .post('/v1/lb/d8ejd7834ht9d9sj345gfsoa')
         .send({ method: 'eth_chainId', id: 1, jsonrpc: '2.0' })
         .set('Accept', 'application/json')
         .set('host', 'eth-mainnet-x')
@@ -1002,7 +1002,7 @@ describe('V1 controller (acceptance)', () => {
 
     for (let i = 1; i <= 5; i++) {
       const response = await client
-        .post('/v1/lb/d8ejd7834ht9d9sj345gfsoaao')
+        .post('/v1/lb/d8ejd7834ht9d9sj345gfsoa')
         .send({ method: 'eth_chainId', id: 1, jsonrpc: '2.0' })
         .set('Accept', 'application/json')
         .set('host', 'eth-mainnet-x')


### PR DESCRIPTION
https://github.com/pokt-foundation/portal-api/blob/d413dada1b3967c27f9fb0ae8cd5e733205402d2/src/sequence.ts#L67

In the sequence, we are replacing slashes with tildes to preserve any slashes at the end. 

After we enabled gigastakes, and simple url redirects we started to hand-craft the load balancer IDs but we were not doing the same replacement that was taking place at sequence.ts. That caused the regex expr that evaluated those simple redirect relays to fail.