### PR TITLE
fix: sync check default vars

### DIFF
--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -168,8 +168,8 @@ export class SyncChecker {
       errorState = true
     }
 
-    let referenceBlockHeight: number
-    let isAltruistTrustworthy: boolean
+    let referenceBlockHeight = 0
+    let isAltruistTrustworthy = false
 
     // Consult altruist for sync source of truth
     const altruistBlockHeight = await this.getSyncFromAltruist(syncCheckOptions, blockchainSyncBackup)

--- a/tests/unit/sync-checker.unit.ts
+++ b/tests/unit/sync-checker.unit.ts
@@ -563,6 +563,44 @@ describe('Sync checker service (unit)', () => {
       expect(expectedLog).to.be.true()
     })
 
+    it('passes sync check due to altruist and network node return sync', async () => {
+      axiosMock.onPost(blockchains['0021']?.altruist).networkError()
+
+      const nodes = DEFAULT_NODES
+
+      const relayer = pocketMock.object()
+      const session = await relayer.getNewSession(undefined)
+
+      const { nodes: syncedNodes } = await syncChecker.consensusFilter({
+        nodes,
+        requestID: '1234',
+        blockchainID: blockchains['0021'].hash,
+        syncCheckOptions: blockchains['0021'].syncCheckOptions,
+        relayer,
+        applicationID: '',
+        applicationPublicKey: '',
+        blockchainSyncBackup: blockchains['0021']?.altruist,
+        pocketAAT: POCKET_AAT,
+        session,
+      })
+
+      expect(syncedNodes).to.have.length(5)
+
+      const expectedAltruistFailureLog = logSpy.calledWith(
+        'info',
+        sinon.match((arg: string) => arg.startsWith('SYNC CHECK ALTRUIST FAILURE'))
+      )
+
+      expect(expectedAltruistFailureLog).to.be.true()
+
+      const expectedSyncCompleteLog = logSpy.calledWith(
+        'info',
+        sinon.match((arg: string) => arg.startsWith('SYNC CHECK COMPLETE'))
+      )
+
+      expect(expectedSyncCompleteLog).to.be.true()
+    })
+
     it('passes sync check with altruist behind and >80% nodes ahead', async () => {
       const nodes = DEFAULT_NODES
 

--- a/tests/unit/sync-checker.unit.ts
+++ b/tests/unit/sync-checker.unit.ts
@@ -563,7 +563,7 @@ describe('Sync checker service (unit)', () => {
       expect(expectedLog).to.be.true()
     })
 
-    it('passes sync check due to altruist and network node return sync', async () => {
+    it('passes sync check on altruist failure, but network node returning sync', async () => {
       axiosMock.onPost(blockchains['0021']?.altruist).networkError()
 
       const nodes = DEFAULT_NODES


### PR DESCRIPTION
If altruist request failed (catch error) the sync check would fail. This PR fixes this bug.