### PR TITLE
fix: parse json rpc err

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,6 +5,8 @@ export function isEVMError(response: string): boolean {
   try {
     const { code } = parseJSONRPCError(response)
 
+    // 3 is execution error
+    // -32000 itself can be thrown for what are server errors, all other -32000 are user errors
     return code === 3 || code < -32000
   } catch {
     return false

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,22 +1,11 @@
 import { parseJSONRPCError } from './parsing'
 
-export const EVM_ERROR_CODES = [
-  // JSON RPC Standard errors
-  '-32',
-  // Execution reverted error
-  '3',
-]
-
 // EVM clients rely on JsonRpc standard, so we check for those errors.
 export function isEVMError(response: string): boolean {
-  return isError(response, EVM_ERROR_CODES)
-}
-
-function isError(response: string, errorsToCheck: string[]): boolean {
   try {
     const { code } = parseJSONRPCError(response)
 
-    return errorsToCheck.some((error) => String(code).includes(error))
+    return code === 3 || code < -32000
   } catch {
     return false
   }

--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -1,4 +1,4 @@
-import jsonrpc, { IParsedObjectError, JsonRpcError } from 'jsonrpc-lite'
+import jsonrpc, { ErrorObject, IParsedObject, JsonRpcError } from 'jsonrpc-lite'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseMethod(parsedRawData: Record<string, any>): string {
@@ -45,16 +45,11 @@ export function parseRPCID(parsedRawData: Record<string, any>): number {
 }
 
 export function parseJSONRPCError(response: string): JsonRpcError {
-  const parsedResponse = jsonrpc.parse(response) as IParsedObjectError
-  const isJSONRpcError = isJSONRPCError(parsedResponse)
+  const parsedResponse = jsonrpc.parse(response) as IParsedObject
 
-  if (isJSONRpcError) {
+  if (parsedResponse.type !== 'invalid' && parsedResponse.payload instanceof ErrorObject) {
     return parsedResponse.payload.error
   }
 
   return { code: 0, message: '' }
-}
-
-export function isJSONRPCError(object: unknown): object is IParsedObjectError {
-  return Object.prototype.hasOwnProperty.call(object, 'type') || Object.prototype.hasOwnProperty.call(object, 'payload')
 }


### PR DESCRIPTION
Pocket core responses to the API were returning invalid JSON-RPC, that made our parsing fail and mark some connection refused errors as user errors (not the case, these should be actual relay errors).

This PR fixes this issue and does proper parsing & handling on invalid JSON-RPC.