### PR TITLE
fix: enforce fallback response integrity & evm user error matching

### DIFF
--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -462,6 +462,12 @@ export class PocketRelayer {
             responseParsed = JSON.parse(fallbackResponse.data)
           }
 
+          const stringifiedResponse = JSON.stringify(responseParsed)
+
+          if (isRelayError(stringifiedResponse)) {
+            throw new Error(`Response is not valid: ${stringifiedResponse}`)
+          }
+
           this.metricsRecorder
             .recordMetric({
               requestID,

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -464,7 +464,7 @@ export class PocketRelayer {
 
           const stringifiedResponse = JSON.stringify(responseParsed)
 
-          if (isRelayError(stringifiedResponse)) {
+          if (isRelayError(stringifiedResponse) && !isUserError(stringifiedResponse)) {
             throw new Error(`Response is not valid: ${stringifiedResponse}`)
           }
 

--- a/src/utils/enforcements.ts
+++ b/src/utils/enforcements.ts
@@ -2,6 +2,8 @@ import { Decryptor } from 'strong-cryptor'
 import { Applications } from '../models'
 import { isUserErrorEVM } from './errors'
 
+const RELAY_ERROR_MSGS = ['{"error"', 'connection error']
+
 export function checkEnforcementJSON(test: string): boolean {
   if (!test || test.length === 0) {
     return false
@@ -66,7 +68,7 @@ export type SecretKeyDetails = {
 }
 
 export function isRelayError(payload: string): boolean {
-  return payload.includes('{"error"')
+  return RELAY_ERROR_MSGS.some((err) => payload.includes(err))
 }
 
 export function isUserError(payload: string, blockchain?: string): boolean {

--- a/src/utils/enforcements.ts
+++ b/src/utils/enforcements.ts
@@ -2,8 +2,6 @@ import { Decryptor } from 'strong-cryptor'
 import { Applications } from '../models'
 import { isUserErrorEVM } from './errors'
 
-const RELAY_ERROR_MSGS = ['{"error"', 'connection error']
-
 export function checkEnforcementJSON(test: string): boolean {
   if (!test || test.length === 0) {
     return false
@@ -68,7 +66,7 @@ export type SecretKeyDetails = {
 }
 
 export function isRelayError(payload: string): boolean {
-  return RELAY_ERROR_MSGS.some((err) => payload.includes(err))
+  return payload.includes('{"error"')
 }
 
 export function isUserError(payload: string, blockchain?: string): boolean {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,19 +1,19 @@
 import { parseJSONRPCError } from './parsing'
 
-// some clients use -32000 for both server/user errors, so message match is needed
-const EVM_USER_ERROR_MSGS = ['execution reverted', 'stack underflow', 'cannot be found', 'missing trie node']
+// Messages thrown by evm clients like Geth that are node fault, not user fault.
+const EVM_SERVER_ERROR_MSGS = ['connection error']
 
 // EVM clients rely on JsonRpc standard, so we check for those errors.
 export function isUserErrorEVM(response: string): boolean {
   try {
     const { code, message } = parseJSONRPCError(response)
 
-    const userError = EVM_USER_ERROR_MSGS.some((err) => message.includes(err))
+    const serverError = EVM_SERVER_ERROR_MSGS.some((err) => message.includes(err))
 
     // 3 is execution error
     // -32000 itself can be thrown for what are server errors
     // all other -32000 are user errors
-    return userError || code === 3 || code < -32000
+    return (!serverError && code === -32000) || code === 3 || code < -32000
   } catch {
     return false
   }


### PR DESCRIPTION
The fallback responses are the ones coming from our backup system. They come into play when the node selected from the network can't do it's job, and doesn't return any response. In our mission to be as fast as we can, we use our internal system to serve that request (doesn't generate revenue).

These responses were only enforced to a certain format, but the truth is that there are other several server errors from blockchain's node clients that indicate that the call wasn't effective. This PR adds some additional text enforcement to abstract these errors from users and let it fail without any specific blockchain's node message that could add confusion to end user.

Example error:
```
{"error":{"code":-32000,"message":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:9090: connect: connection refused\""},"id":732830328053361800,"jsonrpc":"2.0"}
```