### PR TITLE
fix: unproper kicking from session cache

### DIFF
--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -317,11 +317,8 @@ export class ChainChecker {
         sessionKey: key,
       })
 
-      if (relay instanceof EvidenceSealedError || relay instanceof InvalidBlockHeightError) {
+      if (relay instanceof EvidenceSealedError) {
         await removeNodeFromSession(this.cache, session, node.publicKey, true, requestID, blockchainID)
-      }
-      if (relay instanceof InvalidBlockHeightError) {
-        await removeSessionCache(this.cache, pocketAAT.applicationPublicKey, blockchainID)
       }
       if (relay instanceof InvalidSessionError || relay instanceof OutOfSyncRequestError) {
         this.sessionErrors++

--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -3,7 +3,6 @@ import {
   InvalidSessionError,
   EvidenceSealedError,
   OutOfSyncRequestError,
-  InvalidBlockHeightError,
 } from '@pokt-foundation/pocketjs-relayer'
 import { Session, Node, PocketAAT } from '@pokt-foundation/pocketjs-types'
 import extractDomain from 'extract-domain'

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -904,9 +904,6 @@ export class PocketRelayer {
       if (relay instanceof EvidenceSealedError) {
         await removeNodeFromSession(this.cache, session, node.publicKey, true, requestID, blockchainID)
       }
-      if (relay instanceof InvalidBlockHeightError) {
-        await removeSessionCache(this.cache, pocketAAT.applicationPublicKey, blockchainID)
-      }
       return new RelayError(relay.message, 500, node?.publicKey)
       // ConsensusNode
     } else {

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -1,4 +1,4 @@
-import { EvidenceSealedError, InvalidBlockHeightError, Relayer } from '@pokt-foundation/pocketjs-relayer'
+import { EvidenceSealedError, Relayer } from '@pokt-foundation/pocketjs-relayer'
 import { Session, Node, PocketAAT, HTTPMethod } from '@pokt-foundation/pocketjs-types'
 import axios, { AxiosRequestConfig, Method } from 'axios'
 import jsonrpc, { ErrorObject, IParsedObject } from 'jsonrpc-lite'
@@ -10,7 +10,7 @@ import { ChainChecker, ChainIDFilterOptions } from '../services/chain-checker'
 import { CherryPicker } from '../services/cherry-picker'
 import { MetricsRecorder } from '../services/metrics-recorder'
 import { ConsensusFilterOptions, SyncChecker, SyncCheckOptions } from '../services/sync-checker'
-import { removeNodeFromSession, removeSessionCache } from '../utils/cache'
+import { removeNodeFromSession } from '../utils/cache'
 import { SESSION_TIMEOUT, DEFAULT_ALTRUIST_TIMEOUT } from '../utils/constants'
 import {
   checkEnforcementJSON,

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -501,9 +501,6 @@ export class SyncChecker {
       if (relay instanceof EvidenceSealedError) {
         await removeNodeFromSession(this.cache, session, node.publicKey, true, requestID, blockchainID)
       }
-      if (relay instanceof InvalidBlockHeightError) {
-        await removeSessionCache(this.cache, pocketAAT.applicationPublicKey, blockchainID)
-      }
       if (relay instanceof InvalidSessionError || relay instanceof OutOfSyncRequestError) {
         this.sessionErrors++
       }

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -3,7 +3,6 @@ import {
   InvalidSessionError,
   EvidenceSealedError,
   OutOfSyncRequestError,
-  InvalidBlockHeightError,
 } from '@pokt-foundation/pocketjs-relayer'
 import { Session, Node, PocketAAT } from '@pokt-foundation/pocketjs-types'
 import axios from 'axios'


### PR DESCRIPTION
Back two weeks ago, we were experiencing issues with session cache - it was persisting more than it should despite our system expiring the keys. While we were looking for solutions, a bad assumption hit the table: removing nodes from sessions that ran into invalid block messages would take outdated data from the cache.

Unfortunately, that was not a proper solution. The cause of such messages "invalid block height" is a result of outdated cache or dispatchers behind in block height. The actual nodes in the session have nothing to do with that.

What was the impact? A lot of nodes getting kicked out of session cache, very consistently.

This PR takes out the condition to remove from session cache due to "invalid block height" error during relay, or in the checks. It will have previous behavior, to only kick nodes once max relays for that node in session are exhausted (in checks, it also make sure it's not an invalid session, or out of sync).