### PR TITLE
Fix error metrics recorded twice

### DIFF
--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -330,11 +330,6 @@ export class PocketRelayer {
             }
             return relay.response
           } else if (relay instanceof RelayError) {
-            // Record failure metric, retry if possible or fallback
-            // Increment error log
-            await this.cache.incr(blockchainID + '-' + relay.servicer_node + '-errors')
-            await this.cache.expire(blockchainID + '-' + relay.servicer_node + '-errors', 3600)
-
             let error = relay.message
 
             if (typeof relay.message === 'object') {


### PR DESCRIPTION
error metric on a failing node is being recorded twice, once in `metrics-recorder.ts` (which is as intended) and again in `pocket-relayer.ts` (which isn't) this removes the recording from `pocket-relayer.ts`.