### PR TITLE
fix: dispatch log after success + block height

### DIFF
--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -622,13 +622,6 @@ export class PocketRelayer {
       if (cachedSession) {
         session = JSON.parse(cachedSession)
       } else {
-        logger.log('info', 'call to dispatcher to obtain session', {
-          requestID,
-          blockchainID,
-          gatewayPublicKey: application?.gatewayAAT.applicationPublicKey,
-          typeID: application.id,
-        })
-
         session = await this.relayer.getNewSession({
           chain: blockchainID,
           applicationPubKey: application?.gatewayAAT.applicationPublicKey,
@@ -637,6 +630,13 @@ export class PocketRelayer {
             rejectSelfSignedCertificates: false,
             timeout: SESSION_TIMEOUT,
           },
+        })
+
+        logger.log('info', 'success dispatcher call to obtain session', {
+          requestID,
+          blockchainID,
+          gatewayPublicKey: application?.gatewayAAT.applicationPublicKey,
+          typeID: application.id,
         })
 
         // TODO: Remove when sdk does it internally

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -637,6 +637,8 @@ export class PocketRelayer {
           blockchainID,
           gatewayPublicKey: application?.gatewayAAT.applicationPublicKey,
           typeID: application.id,
+          blockHeight: session?.blockHeight,
+          sessionBlockHeight: session?.header?.sessionBlockHeight,
         })
 
         // TODO: Remove when sdk does it internally


### PR DESCRIPTION
This PR moves down the dispatch call logging after it has been successful, to avoid log duplicity when an error happens. As of now, if there was an error obtaining session both would get logged.

It also adds block heights to the log, this is useful to quickly determine if dispatchers are returning old data. Our dispatcher system takes out nodes that are out of sync automatically, but this adds extra visibility in case it's not working as expected at a given time.