### PR TITLE
feat: add block height facets to sync behind log

### DIFF
--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -267,6 +267,9 @@ export class SyncChecker {
           serviceURL,
           serviceDomain,
           sessionKey,
+          referenceBlockHeight,
+          nodeBlockHeight: blockHeight,
+          syncDiff: referenceBlockHeight - blockHeight,
         })
 
         this.metricsRecorder

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -241,7 +241,7 @@ export class SyncChecker {
         ? altruistBlockHeight + syncAllowance
         : highestNodeBlockHeight + syncAllowance
 
-      if (correctedNodeBlockHeight >= referenceBlockHeight && nodeSyncLog.blockHeight <= maximumBlockHeight) {
+      if (correctedNodeBlockHeight >= referenceBlockHeight && blockHeight <= maximumBlockHeight) {
         logger.log('info', 'SYNC CHECK IN-SYNC: ' + node.publicKey + ' height: ' + blockHeight, {
           requestID: requestID,
           blockchainID,
@@ -250,6 +250,7 @@ export class SyncChecker {
           serviceURL: node,
           serviceDomain,
           sessionKey,
+          blockHeight,
         })
 
         // Erase failure mark
@@ -259,7 +260,7 @@ export class SyncChecker {
         syncedNodes.push(node)
         syncedNodesList.push(node.publicKey)
       } else {
-        logger.log('info', 'SYNC CHECK BEHIND: ' + node.publicKey + ' height: ' + nodeSyncLog.blockHeight, {
+        logger.log('info', 'SYNC CHECK BEHIND: ' + node.publicKey + ' height: ' + blockHeight, {
           requestID: requestID,
           blockchainID,
           serviceNode: node.publicKey,


### PR DESCRIPTION
As of now, the block heights are only recorded in the error string. This is not very helpful to use in Datadog and we'll need it to make an strategy to balance out the sync allowance depending on how often nodes are out of sync.