### PR TITLE
fix: cache failure key name & initial failure key TTL

### DIFF
--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -483,7 +483,7 @@ export class CherryPicker {
         // If previously marked as failure, erase that
         if (failure) {
           failure = false
-          await this.redis.set(`{${blockchain}}-${id}-failure`, 'false', 'EX', 60 * 60 * 24 * 30)
+          await this.redis.set(`{${blockchain}}-${id}-failure`, 'false', 'EX', 60 * 60 * 2)
         }
         successRate = parsedLog.results['200'] / attempts
         medianSuccessLatency = parseFloat(parseFloat(parsedLog.medianSuccessLatency).toFixed(5))

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -253,7 +253,7 @@ export class SyncChecker {
         })
 
         // Erase failure mark
-        await this.cache.set(blockchainID + '-' + node.publicKey + '-failure', 'false', 'EX', 60 * 60 * 24 * 30)
+        await this.cache.set(`{${blockchainID}}-${node.publicKey}-failure`, 'false', 'EX', 60 * 60 * 24 * 30)
 
         // In-sync: add to nodes list
         syncedNodes.push(node)

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -253,7 +253,7 @@ export class SyncChecker {
         })
 
         // Erase failure mark
-        await this.cache.set(`{${blockchainID}}-${node.publicKey}-failure`, 'false', 'EX', 60 * 60 * 24 * 30)
+        await this.cache.set(`{${blockchainID}}-${node.publicKey}-failure`, 'false', 'EX', 60 * 60 * 2)
 
         // In-sync: add to nodes list
         syncedNodes.push(node)


### PR DESCRIPTION
IMPORTANT: This does not modify the cherry picker algorithm nor the logic.

This PR updates the failure key name so it uses `{}` as it does in the rest of the code, and sets the initial TTL of the failure mark to 2 hours.

Reasoning: the Redis keys should include `{}` at the beginning to avoid undesirable Redis cluster errors. A while back, it was updated to do so in the cherry picker so it fetches the values with those keys, but it wasn't modified in the sync check. There was a mismatch in the key naming in the code-base, which this PR fixes.

This key naming mismatch led to an accumulation of keys over time since they were not expiring properly (the initial TTL was 30 days) - after certain point, the Redis instance would crash due this accumulation. For safety, we are adjusting the TTL for 2 hours - failure keys don't really need to persist for longer than.