### PR TITLE
Add app public key metadata to Cherry picker

### DIFF
--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -227,7 +227,7 @@ export class CherryPicker {
         p90: number
         attempts: number
         successRate: number
-        applicationPubKey: string
+        applicationPublicKey: string
       }
     }
 
@@ -266,7 +266,7 @@ export class CherryPicker {
           p90: bucketedServiceQuality.p90,
           attempts: unsortedLog.attempts,
           successRate: unsortedLog.successRate,
-          applicationPubKey: session.header.applicationPubKey,
+          applicationPublicKey: session.header.applicationPubKey,
         }
       } else {
         await this.updateBadNodeTimeoutQuality(blockchain, id, elapsedTime, timeout, session)
@@ -289,7 +289,7 @@ export class CherryPicker {
           p90: bucketedServiceQuality.p90,
           attempts: 1,
           successRate: unsortedLog.successRate,
-          applicationPubKey: session.header.applicationPubKey,
+          applicationPublicKey: session.header.applicationPubKey,
         },
       }
     }

--- a/src/services/cherry-picker.ts
+++ b/src/services/cherry-picker.ts
@@ -227,6 +227,7 @@ export class CherryPicker {
         p90: number
         attempts: number
         successRate: number
+        applicationPubKey: string
       }
     }
 
@@ -265,6 +266,7 @@ export class CherryPicker {
           p90: bucketedServiceQuality.p90,
           attempts: unsortedLog.attempts,
           successRate: unsortedLog.successRate,
+          applicationPubKey: session.header.applicationPubKey,
         }
       } else {
         await this.updateBadNodeTimeoutQuality(blockchain, id, elapsedTime, timeout, session)
@@ -287,6 +289,7 @@ export class CherryPicker {
           p90: bucketedServiceQuality.p90,
           attempts: 1,
           successRate: unsortedLog.successRate,
+          applicationPubKey: session.header.applicationPubKey,
         },
       }
     }

--- a/tests/unit/cherry-picker.unit.ts
+++ b/tests/unit/cherry-picker.unit.ts
@@ -252,7 +252,7 @@ describe('Cherry picker service (unit)', () => {
         metadata: {
           attempts: 1,
           successRate: 1,
-          applicationPubKey: session.header.applicationPubKey,
+          applicationPublicKey: session.header.applicationPubKey,
         },
       })
       let logs: string
@@ -284,7 +284,7 @@ describe('Cherry picker service (unit)', () => {
           attempts: 26,
           p90: 0.262,
           successRate: 0.9230769230769231,
-          applicationPubKey: session.header.applicationPubKey,
+          applicationPublicKey: session.header.applicationPubKey,
         },
       })
 

--- a/tests/unit/cherry-picker.unit.ts
+++ b/tests/unit/cherry-picker.unit.ts
@@ -240,6 +240,7 @@ describe('Cherry picker service (unit)', () => {
       const blockchain = '0027'
       const elapseTime = 0.22333
       const result = 500
+      const session = await new PocketMock().object().getNewSession(undefined)
       const expectedLogs = JSON.stringify({
         medianSuccessLatency: '0.00000',
         weightedSuccessLatency: '0.00000',
@@ -251,6 +252,7 @@ describe('Cherry picker service (unit)', () => {
         metadata: {
           attempts: 1,
           successRate: 1,
+          applicationPubKey: session.header.applicationPubKey,
         },
       })
       let logs: string
@@ -258,8 +260,6 @@ describe('Cherry picker service (unit)', () => {
       // no values set for the service yet
       logs = await redis.get(`{${blockchain}}-${id}-service`)
       expect(logs).to.be.null()
-
-      const session = await new PocketMock().object().getNewSession(undefined)
 
       await cherryPicker.updateServiceQuality(blockchain, id, elapseTime, result, session)
 
@@ -272,6 +272,7 @@ describe('Cherry picker service (unit)', () => {
       const blockchain = '0027'
       const elapseTime = 0.22333 // logs are set to be up to 5 decimal points
       const result = 200
+      const session = await new PocketMock().object().getNewSession(undefined)
       const expectedLogs = JSON.stringify({
         medianSuccessLatency: '0.25000',
         weightedSuccessLatency: '0.32860', // average after calculation from fn
@@ -283,6 +284,7 @@ describe('Cherry picker service (unit)', () => {
           attempts: 26,
           p90: 0.262,
           successRate: 0.9230769230769231,
+          applicationPubKey: session.header.applicationPubKey,
         },
       })
 
@@ -294,7 +296,6 @@ describe('Cherry picker service (unit)', () => {
         'EX',
         60
       )
-      const session = await new PocketMock().object().getNewSession(undefined)
 
       await cherryPicker.updateServiceQuality(blockchain, id, elapseTime, result, session)
       const logs = await redis.get(`{${blockchain}}-${id}-service`)


### PR DESCRIPTION
Note: This does not modify the algorithm in any way
Add Application's public key to cherry picker metadata. This is so the cherry picker database can easily identified to which apps the active session belongs