### PR TITLE
Chains mapping endpoint

### DIFF
--- a/src/controllers/blockchains.controller.ts
+++ b/src/controllers/blockchains.controller.ts
@@ -59,4 +59,29 @@ export class BlockchainsController {
   ): Promise<Blockchains> {
     return this.blockchainsRepository.findById(id, filter)
   }
+
+  @get('/blockchains/ids', {
+    responses: {
+      '200': {
+        description: 'Mapping of available blockchains and their API aliases',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'array',
+              items: getModelSchemaRef(Blockchains, { includeRelations: true }),
+            },
+          },
+        },
+      },
+    },
+  })
+  async idsMapping(@param.filter(Blockchains) filter?: Filter<Blockchains>): Promise<object> {
+    const blockchains = await this.blockchainsRepository.find(filter)
+
+    const aliases = {}
+    blockchains.forEach((blockchain) => {
+      aliases[blockchain.hash] = blockchain.blockchainAliases
+    })
+    return aliases
+  }
 }

--- a/src/controllers/blockchains.controller.ts
+++ b/src/controllers/blockchains.controller.ts
@@ -80,7 +80,10 @@ export class BlockchainsController {
 
     const aliases = {}
     blockchains.forEach((blockchain) => {
-      aliases[blockchain.hash] = blockchain.blockchainAliases
+      aliases[blockchain.description] = {
+        id: blockchain.hash,
+        prefix: blockchain.blockchainAliases,
+      }
     })
     return aliases
   }

--- a/src/controllers/blockchains.controller.ts
+++ b/src/controllers/blockchains.controller.ts
@@ -67,7 +67,6 @@ export class BlockchainsController {
         content: {
           'application/json': {
             schema: {
-              type: 'array',
               items: getModelSchemaRef(Blockchains, { includeRelations: true }),
             },
           },

--- a/tests/acceptance/blockchain.controller.acceptance.tests.ts
+++ b/tests/acceptance/blockchain.controller.acceptance.tests.ts
@@ -96,9 +96,12 @@ describe('Blockchains controller (acceptance)', () => {
 
     expect(res.body).to.be.Object()
 
-    const blockchainID = '0'
-    expect(res.body[blockchainID]).to.be.Array()
-    expect(res.body[blockchainID]).to.have.length(1)
+    const blockchainID = 'Kovan'
+    expect(res.body[blockchainID].prefix).to.be.Array()
+    expect(res.body[blockchainID].prefix).to.have.length(1)
+
+    expect(res.body[blockchainID].id).to.be.String()
+    expect(res.body[blockchainID].id).to.be.equal('0')
   })
 
   async function generateBlockchains(amount: number): Promise<Partial<Blockchains>[]> {

--- a/tests/acceptance/blockchain.controller.acceptance.tests.ts
+++ b/tests/acceptance/blockchain.controller.acceptance.tests.ts
@@ -89,6 +89,18 @@ describe('Blockchains controller (acceptance)', () => {
     await client.get('/blockchains/nope').expect(404)
   })
 
+  it('generate a mapping of the available aliases for the chains', async () => {
+    await generateBlockchains(1)
+
+    const res = await client.get('/blockchains/ids').expect(200)
+
+    expect(res.body).to.be.Object()
+
+    const blockchainID = '0'
+    expect(res.body[blockchainID]).to.be.Array()
+    expect(res.body[blockchainID]).to.have.length(1)
+  })
+
   async function generateBlockchains(amount: number): Promise<Partial<Blockchains>[]> {
     const blockchains = []
 


### PR DESCRIPTION
Adds a new endpoint `blockchains/ids` where all the available chains are listed in a JSON object exposing their ID and API aliases

