### PR TITLE
fix: handles invalid eth raw tx bytes

### DIFF
--- a/src/utils/evm/parsing.ts
+++ b/src/utils/evm/parsing.ts
@@ -1,28 +1,36 @@
 import { utils } from 'ethers'
 import { parseMethod } from '../parsing'
 
+const logger = require('../../services/logger')
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function extractContractAddress(rawData: Record<string, any>): string | undefined {
-  const params = rawData.params
-  const method = parseMethod(rawData)
+  try {
+    const params = rawData.params
+    const method = parseMethod(rawData)
 
-  switch (method) {
-    case 'eth_sendRawTransaction':
-      return decodeEthRawTxAddress(params[0])
-    case 'eth_call':
-      // firstParameter is the raw tx hex
-      return params[0]?.to
-    case 'eth_getLogs':
-      return params[0]?.address
-    case 'eth_getCode':
-    case 'eth_getBalance':
-    case 'eth_getStorageAt':
-    case 'eth_getTransactionCount':
-      // firstParameter is the address
-      return params[0]
-    default:
-      // If the method is not supported, return undefined
-      return undefined
+    switch (method) {
+      case 'eth_sendRawTransaction':
+        return decodeEthRawTxAddress(params[0])
+      case 'eth_call':
+        // firstParameter is the raw tx hex
+        return params[0]?.to
+      case 'eth_getLogs':
+        return params[0]?.address
+      case 'eth_getCode':
+      case 'eth_getBalance':
+      case 'eth_getStorageAt':
+      case 'eth_getTransactionCount':
+        // firstParameter is the address
+        return params[0]
+      default:
+        // If the method is not supported, return undefined
+        return undefined
+    }
+  } catch (err) {
+    logger.log('warn', 'Error decoding eth transaction', {
+      error: JSON.stringify(err),
+    })
   }
 }
 

--- a/tests/unit/evm-utils.unit.ts
+++ b/tests/unit/evm-utils.unit.ts
@@ -12,8 +12,7 @@ describe('EVM utilities (unit)', () => {
   })
 
   describe('Extract contract addresses', () => {
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('should return undefined when address cannot be extracted from call', () => {
+    it('should return undefined when address cannot be extracted from call', () => {
       const call = {
         id: 1,
         jsonrpc: '2.0',

--- a/tests/unit/evm-utils.unit.ts
+++ b/tests/unit/evm-utils.unit.ts
@@ -12,6 +12,22 @@ describe('EVM utilities (unit)', () => {
   })
 
   describe('Extract contract addresses', () => {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('should return undefined when address cannot be extracted from call', () => {
+      const call = {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'eth_sendRawTransaction',
+        params: [
+          '0x02f89382d2af82020a8402625a008402625a0083830b0994e9abfbc143d7cef74b5b793ec5907fa62ca5315480a4528be0a9000000000000000000000000000000000000000000000000000000000001b3adc001a0c6f95fb46560bd59bf40a787e67649dc74c213eb5be4304249feb8ebc37753bca079c7f1e23eac1fe3185d1d7da8ac23c2b0eaba136039ea5ce2a83879fa7b3d29',
+        ],
+      }
+
+      const address = extractContractAddress(call)
+
+      expect(address).to.to.be.equal(undefined)
+    })
+
     it('should successfully extract contract address from a `eth_sendRawTransaction` call', () => {
       const call = {
         id: 1,


### PR DESCRIPTION
Interesting enough, it seems some wallets are generating invalid raw tx bytes that cannot be parsed by using RLP decoder from `ethers.js`. 

The fact that we are unable to parse them, is blocking these txs from passing but it is not gateway's business to stop those that seem "invalid" or at least unparseable. It only happens in very specific cases but this PR allows them to pass without applying restrictions to these calls.