### PR TITLE
fix: empty params object error

### DIFF
--- a/src/utils/evm/parsing.ts
+++ b/src/utils/evm/parsing.ts
@@ -3,7 +3,7 @@ import { parseMethod } from '../parsing'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function extractContractAddress(rawData: Record<string, any>): { fromAddress: string; toAddress: string } {
-  const params = rawData.params
+  const params = rawData.params !== undefined ? rawData.params : {}
   const method = parseMethod(rawData)
 
   switch (method) {


### PR DESCRIPTION
Fixes the error when trying to decode the address of a contract which may not specify it,. Defaults to undefined as the default case of the switch where is being consumed