### PR TITLE
feat: rate limit enforcement

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -140,7 +140,7 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
 
     const localRedis = new Redis(localRedisConfig.port, localRedisConfig.host)
 
-    const cache = new Cache(remoteRedis as Redis, localRedis, ttlFactor)
+    const cache = new Cache(remoteRedis as Redis.Redis, localRedis, ttlFactor)
 
     this.bind('cache').to(cache)
 
@@ -151,7 +151,7 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
     let rdsCertificate: string
 
     if (environment === 'production') {
-      rdsCertificate = await getRDSCertificate(remoteRedis as Redis, psqlCertificate)
+      rdsCertificate = await getRDSCertificate(remoteRedis as Redis.Redis, psqlCertificate)
     }
 
     const pgPool = new pg.Pool({

--- a/src/application.ts
+++ b/src/application.ts
@@ -140,7 +140,7 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
 
     const localRedis = new Redis(localRedisConfig.port, localRedisConfig.host)
 
-    const cache = new Cache(remoteRedis as Redis.Redis, localRedis, ttlFactor)
+    const cache = new Cache(remoteRedis as Redis, localRedis, ttlFactor)
 
     this.bind('cache').to(cache)
 
@@ -151,7 +151,7 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
     let rdsCertificate: string
 
     if (environment === 'production') {
-      rdsCertificate = await getRDSCertificate(remoteRedis as Redis.Redis, psqlCertificate)
+      rdsCertificate = await getRDSCertificate(remoteRedis as Redis, psqlCertificate)
     }
 
     const pgPool = new pg.Pool({

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -330,9 +330,8 @@ export class V1Controller {
 
       if (shouldLimit) {
         logger.log(
-          'warn',
-          'relay count on application associated with the endpoint has exceeded the rate limit ' +
-            gigastakeOptions?.originalAppID,
+          'error',
+          'relay count on application associated with the endpoint has exceeded the rate limit ' + rateLimitTargetApp,
           {
             requestID: this.requestID,
             relayType: 'LB',

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -340,12 +340,12 @@ export class V1Controller {
             serviceNode: '',
             origin: this.origin,
           }
-          
-          return jsonrpc.error(
-            reqRPCID,
-            new jsonrpc.JsonRpcError('Rate limit exceeded. Please upgrade your plan.', -32068)
-          ) as ErrorObject
         )
+
+        return jsonrpc.error(
+          reqRPCID,
+          new jsonrpc.JsonRpcError('Rate limit exceeded. Please upgrade your plan.', -32068)
+        ) as ErrorObject
       }
 
       if (gigastakeOptions?.gatewaySettings) {

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -321,7 +321,7 @@ export class V1Controller {
         const shouldLimit = await shouldRateLimit(application.id, this.rateLimiterURL, this.cache)
         if (shouldLimit) {
           logger.log(
-            'warn',
+            'error',
             'relay count on application associated with the endpoint has exceeded the rate limit ' + application.id,
             {
               requestID: this.requestID,
@@ -331,6 +331,11 @@ export class V1Controller {
               origin: this.origin,
             }
           )
+
+          return jsonrpc.error(
+            reqRPCID,
+            new jsonrpc.JsonRpcError('Rate limit exceeded. Please upgrade your plan.', -32068)
+          ) as ErrorObject
         }
       }
 
@@ -452,13 +457,18 @@ export class V1Controller {
 
       const shouldLimit = await shouldRateLimit(applicationID, this.rateLimiterURL, this.cache)
       if (shouldLimit) {
-        logger.log('warn', 'application relay count has exceeded the rate limit ' + applicationID, {
+        logger.log('error', 'application relay count has exceeded the rate limit ' + applicationID, {
           requestID: this.requestID,
           relayType: 'APP',
           typeID: id,
           serviceNode: '',
           origin: this.origin,
         })
+
+        return jsonrpc.error(
+          reqRPCID,
+          new jsonrpc.JsonRpcError('Rate limit exceeded. Please upgrade your plan.', -32068)
+        ) as ErrorObject
       }
 
       const { stickiness, duration, useRPCID, relaysLimit, stickyOrigins } =

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -1196,7 +1196,7 @@ describe('V1 controller (acceptance)', () => {
     })
 
     it('logs an error on rate-limiter call failure & relay succeeds', async () => {
-      // Mocking empty rate-limited apps list
+      // Mocking failure to fetch rate-limiter
       axiosMock.onGet('https://rate.limiter').reply(500)
 
       const pocket = pocketMock.object()


### PR DESCRIPTION
Currently the rate limiting is on warn-only mode. This PR introduces actual enforcement that is going to be needed for our Pokemon release.