### PR TITLE
fix: remove domain overwrite on simple redirects

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -18,7 +18,7 @@ import { PocketRelayer } from '../services/pocket-relayer'
 import { SyncChecker } from '../services/sync-checker'
 import { checkWhitelist, RateLimiter, shouldRateLimit } from '../utils/enforcements'
 import { parseRawData, parseRPCID } from '../utils/parsing'
-import { getBlockchainAliasesByDomain, loadBlockchain } from '../utils/relayer'
+import { loadBlockchain } from '../utils/relayer'
 import { SendRelayOptions } from '../utils/types'
 const logger = require('../services/logger')
 
@@ -140,18 +140,6 @@ export class V1Controller {
 
       rpcID = parseRPCID(parsedRawData)
 
-      // Since we only have non-gateway url, let's fetch a blockchain that contains this domain
-      const { blockchainAliases } = await getBlockchainAliasesByDomain(
-        this.host,
-        this.cache,
-        this.blockchainsRepository,
-        rpcID
-      )
-
-      // Any alias works to load a specific blockchain
-      // TODO: Move URL to ENV
-      this.host = `${blockchainAliases[0]}.gateway.pokt.network`
-
       const { blockchainRedirects, blockchainPath } = await loadBlockchain(
         this.host,
         this.cache,
@@ -162,10 +150,6 @@ export class V1Controller {
 
       for (const redirect of blockchainRedirects) {
         if (this.pocketRelayer.host.toLowerCase().includes(redirect.domain)) {
-          // Modify the host using the stored blockchain name in DB
-          this.pocketRelayer.host = redirect.alias
-          this.host = redirect.alias
-
           // convert the slashes to tildes for processing in the loadBalancerRelay route
           const lbID = `${redirect.loadBalancerID}${blockchainPath}`.replace(/\//gi, '~')
 
@@ -273,7 +257,7 @@ export class V1Controller {
           if (!loadBalancer?.id) {
             throw new ErrorObject(
               reqRPCID,
-              new jsonrpc.JsonRpcError(`GS (${redirect.alias}) load balancer not found`, -32054)
+              new jsonrpc.JsonRpcError(`${redirect.alias} gigastake load balancer not found`, -32054)
             )
           }
 
@@ -767,7 +751,10 @@ export class V1Controller {
     const loadBalancer = await this.fetchLoadBalancer(redirect.loadBalancerID, filter)
 
     if (!loadBalancer?.id) {
-      throw new ErrorObject(rpcID, new jsonrpc.JsonRpcError(`GS (${redirect.alias}) load balancer not found`, -32054))
+      throw new ErrorObject(
+        rpcID,
+        new jsonrpc.JsonRpcError(`${redirect.alias} gigastake load balancer not found`, -32054)
+      )
     }
 
     const application = await this.fetchLoadBalancerApplication(

--- a/src/utils/relayer.ts
+++ b/src/utils/relayer.ts
@@ -51,6 +51,7 @@ export async function loadBlockchain(
   // Split off the first part of the request's host and check for matches
   const [blockchainRequest] = host.split('.')
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let blockchainFilter: any
 
   // Search by blockchain alias (f.g. match 'eth-mainnet')

--- a/src/utils/relayer.ts
+++ b/src/utils/relayer.ts
@@ -51,12 +51,25 @@ export async function loadBlockchain(
   // Split off the first part of the request's host and check for matches
   const [blockchainRequest] = host.split('.')
 
-  const [blockchainFilter] = blockchains.filter((b: { blockchainAliases: string[] }) =>
+  let blockchainFilter: any
+
+  // Search by blockchain alias (f.g. match 'eth-mainnet')
+  const [blockchainAliasFilter] = blockchains.filter((b: { blockchainAliases: string[] }) =>
     b.blockchainAliases.some((alias) => alias.toLowerCase() === blockchainRequest.toLowerCase())
   )
+  blockchainFilter = blockchainAliasFilter
 
-  if (!blockchainFilter) {
-    throw new ErrorObject(rpcID, new jsonrpc.JsonRpcError(`Incorrect blockchain: ${host}`, -32057))
+  // If there is no match using alias, try with redirect domain (f.g. match 'eth-rpc.gateway.pokt.network')
+  if (!blockchainAliasFilter) {
+    const [blockchainDomainFilter] = blockchains.filter((b: { redirects: BlockchainRedirect[] }) =>
+      b.redirects?.some((rdr) => rdr.domain.toLowerCase() === host.toLowerCase())
+    )
+    blockchainFilter = blockchainDomainFilter
+
+    // No blockchain match with either alias/domain. Blockchain must be incorrect.
+    if (!blockchainDomainFilter) {
+      throw new ErrorObject(rpcID, new jsonrpc.JsonRpcError(`Incorrect blockchain: ${host}`, -32057))
+    }
   }
 
   let blockchainEnforceResult = ''
@@ -69,11 +82,8 @@ export async function loadBlockchain(
   let blockchainRedirects = [] as BlockchainRedirect[]
   const blockchainSyncCheck = {} as SyncCheckOptions
 
-  const blockchain = blockchainFilter.blockchainAliases.find((alias: string) => {
-    if (alias.toLowerCase() === blockchainRequest.toLowerCase()) {
-      return alias // ex. 'eth-mainnet'
-    }
-  })
+  // ex. 'eth-mainnet', 'eth-rpc', 'poly-mainnet'
+  const blockchain = blockchainRequest
 
   blockchainID = blockchainFilter.hash as string // ex. '0021'
 
@@ -131,39 +141,4 @@ export async function loadBlockchain(
     blockchainAltruist,
     blockchainRedirects,
   } as BlockchainDetails)
-}
-
-// Get blockchain's alias by it's redirect domain
-export async function getBlockchainAliasesByDomain(
-  host: string,
-  redis: Cache,
-  blockchainsRepository: BlockchainsRepository,
-  rpcID: number
-): Promise<{ blockchainAliases: string[] }> {
-  // Load the requested blockchain
-  const cachedBlockchains = await redis.get('blockchains')
-  let blockchains
-
-  if (!cachedBlockchains) {
-    blockchains = await blockchainsRepository.find()
-    await redis.set('blockchains', JSON.stringify(blockchains), 'EX', 60)
-  } else {
-    blockchains = JSON.parse(cachedBlockchains)
-  }
-
-  const [blockchainFilter] = blockchains.filter((b: { redirects: BlockchainRedirect[] }) =>
-    b.redirects?.some((rdr) => rdr.domain.toLowerCase() === host.toLowerCase())
-  )
-
-  if (!blockchainFilter) {
-    throw new ErrorObject(rpcID, new jsonrpc.JsonRpcError(`Unable to find a blockchain with domain: ${host}`, -32057))
-  }
-
-  let blockchainAliases: string[]
-
-  if (blockchainFilter.blockchainAliases) {
-    blockchainAliases = blockchainFilter.blockchainAliases
-  }
-
-  return Promise.resolve({ blockchainAliases })
 }

--- a/tests/acceptance/v1.controller.acceptance.ts
+++ b/tests/acceptance/v1.controller.acceptance.ts
@@ -1983,8 +1983,7 @@ describe('V1 controller (acceptance)', () => {
       expect(response.body.error.message).to.startWith('Restricted endpoint: contract address not allowed')
     })
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('invokes POST /v1/{appId} and successfully relays a request only through the altruist', async () => {
+    it('invokes POST /v1/{appId} and successfully relays a request only through the altruist', async () => {
       const pocket = pocketMock.object()
       const logSpy = sinon.spy(logger, 'log')
 


### PR DESCRIPTION
This is a complementary PR for #975. 

The way that simple redirects were designed does not allow for a nice way to log the redirect domain, because it gets overwritten for the specific blockchain alias. This PR removes this domain overwrite to be able to log the redirect domain correctly.