### PR TITLE
feat: add region label to loki transport

### DIFF
--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -123,7 +123,7 @@ const options = {
     host: lokiHost,
     basicAuth: lokiBasicAuth,
     json: true,
-    labels: { app: logName },
+    labels: { app: logName, hostname: os.hostname(), source: 'nodejs', region: region },
     format: format.json(),
     replaceTimestamp: true,
     onConnectionError: (err) => console.error(err),


### PR DESCRIPTION
There are a few missing labels on the loki transport that are in Datadog, and are necessary in logging.