### PR TITLE
fix: remove os host from influx data points

### DIFF
--- a/src/services/metrics-recorder.ts
+++ b/src/services/metrics-recorder.ts
@@ -10,7 +10,6 @@ import { Point, WriteApi } from '@influxdata/influxdb-client'
 
 import { BLOCK_TIMING_ERROR, CheckMethods } from '../utils/constants'
 import { CherryPicker } from './cherry-picker'
-const os = require('os')
 const logger = require('../services/logger')
 
 export class MetricsRecorder {
@@ -206,7 +205,6 @@ export class MetricsRecorder {
         .tag('result', result.toString())
         .tag('blockchain', blockchainID) // 0021
         .tag('blockchainSubdomain', blockchain) // eth-mainnet
-        .tag('host', os.hostname())
         .tag('region', process.env.REGION || '')
         .floatField('bytes', bytes)
         .floatField('elapsedTime', elapsedTime.toFixed(4))

--- a/tests/unit/metrics-recorder.unit.ts
+++ b/tests/unit/metrics-recorder.unit.ts
@@ -7,7 +7,6 @@ import { MetricsRecorder } from '../../src/services/metrics-recorder'
 
 // import { metricsRecorderMock } from '../mocks/metrics-recorder'
 
-const os = require('os')
 const Redis = require('ioredis-mock')
 
 describe('Metrics Recorder (unit)', () => {
@@ -90,7 +89,6 @@ describe('Metrics Recorder (unit)', () => {
           .tag('result', '500')
           .tag('blockchain', '0021') // 0021
           .tag('blockchainSubdomain', 'eth-mainnet') // eth-mainnet
-          .tag('host', os.hostname())
           .tag('region', process.env.REGION || '')
           .floatField('bytes', 5)
 
@@ -139,7 +137,6 @@ describe('Metrics Recorder (unit)', () => {
           .tag('result', '500')
           .tag('blockchain', '0021') // 0021
           .tag('blockchainSubdomain', 'eth-mainnet') // eth-mainnet
-          .tag('host', os.hostname())
           .tag('region', process.env.REGION || '')
           .floatField('bytes', 5)
 


### PR DESCRIPTION
Given how our infrastructure dynamically scales up/down, the amount of host names produced are too much for a time-series DB. This host name isn't really helpful at all on Influx, it is the most useful for logging.

This alongside #1007 should reduce cardinality by a lot.